### PR TITLE
Add Counter and Quote child napkins to example app

### DIFF
--- a/Examples/LaunchNapkin/CounterNapkinBuilder.swift
+++ b/Examples/LaunchNapkin/CounterNapkinBuilder.swift
@@ -1,0 +1,47 @@
+//
+//  CounterNapkinBuilder.swift
+//  napkin
+//
+//  Created by nonplus on 5/4/26.
+//
+
+import napkin
+
+protocol CounterNapkinDependency: Dependency {
+    // Declare the set of dependencies required by this napkin, but cannot be
+    // created by this napkin.
+}
+
+final class CounterNapkinComponent: Component<CounterNapkinDependency>, @unchecked Sendable {
+
+    // Declare 'fileprivate' dependencies that are only used by this napkin.
+}
+
+// MARK: - Builder
+
+protocol CounterNapkinBuildable: Buildable {
+    @MainActor func build(withListener listener: CounterNapkinListener) async -> CounterNapkinRouting
+}
+
+final class CounterNapkinBuilder:
+    Builder<CounterNapkinDependency>,
+    CounterNapkinBuildable,
+    @unchecked Sendable
+{
+
+    override init(dependency: CounterNapkinDependency) {
+        super.init(dependency: dependency)
+    }
+
+    @MainActor
+    func build(withListener listener: CounterNapkinListener) async -> CounterNapkinRouting {
+        let component = CounterNapkinComponent(dependency: dependency)
+        _ = component
+        let viewController = CounterNapkinViewController()
+        let interactor = CounterNapkinInteractor(presenter: viewController)
+        await interactor.set(listener: listener)
+        let router = CounterNapkinRouter(interactor: interactor, viewController: viewController)
+        await interactor.set(router: router)
+        return router
+    }
+}

--- a/Examples/LaunchNapkin/CounterNapkinHostingViewController.swift
+++ b/Examples/LaunchNapkin/CounterNapkinHostingViewController.swift
@@ -1,0 +1,65 @@
+//
+//  CounterNapkinHostingViewController.swift
+//  napkin
+//
+//  Created by nonplus on 5/4/26.
+//
+
+import napkin
+import SwiftUI
+
+protocol CounterNapkinPresentableListener: AnyObject, Sendable {
+    func didTapIncrement() async
+    func didTapDecrement() async
+    func didTapDone() async
+}
+
+#if canImport(UIKit)
+@MainActor
+final class CounterNapkinViewController:
+    UIHostingController<CounterNapkinView>,
+    CounterNapkinPresentable
+{
+
+    weak var listener: CounterNapkinPresentableListener? {
+        didSet { rootView.listener = listener }
+    }
+
+    init() {
+        super.init(rootView: CounterNapkinView())
+    }
+
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(count: Int) async {
+        rootView.count = count
+    }
+}
+#elseif canImport(AppKit)
+@MainActor
+final class CounterNapkinViewController:
+    NSHostingController<CounterNapkinView>,
+    CounterNapkinPresentable
+{
+
+    weak var listener: CounterNapkinPresentableListener? {
+        didSet { rootView.listener = listener }
+    }
+
+    init() {
+        super.init(rootView: CounterNapkinView())
+    }
+
+    @MainActor required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(count: Int) async {
+        rootView.count = count
+    }
+}
+#endif
+
+extension CounterNapkinViewController: CounterNapkinViewControllable {}

--- a/Examples/LaunchNapkin/CounterNapkinInteractor.swift
+++ b/Examples/LaunchNapkin/CounterNapkinInteractor.swift
@@ -1,0 +1,77 @@
+//
+//  CounterNapkinInteractor.swift
+//  napkin
+//
+//  Created by nonplus on 5/4/26.
+//
+
+import napkin
+
+@MainActor
+protocol CounterNapkinRouting: ViewableRouting, Sendable {
+    // Declare methods the interactor can invoke to manage sub-tree via the router.
+}
+
+protocol CounterNapkinPresentable: Presentable, Sendable {
+    @MainActor var listener: CounterNapkinPresentableListener? { get set }
+    func update(count: Int) async
+}
+
+protocol CounterNapkinListener: AnyObject, Sendable {
+    func counterDidFinish() async
+}
+
+final actor CounterNapkinInteractor: PresentableInteractable, CounterNapkinPresentableListener {
+
+    nonisolated let lifecycle = InteractorLifecycle()
+    nonisolated let presenter: CounterNapkinPresentable
+
+    weak var router: CounterNapkinRouting?
+    weak var listener: CounterNapkinListener?
+
+    private var count: Int = 0
+
+    init(presenter: CounterNapkinPresentable) {
+        self.presenter = presenter
+    }
+
+    func set(router: CounterNapkinRouting?) {
+        self.router = router
+    }
+
+    func set(listener: CounterNapkinListener?) {
+        self.listener = listener
+    }
+
+    func didBecomeActive() async {
+        let initialCount = self.count
+        let presenter = self.presenter
+        await presenter.update(count: initialCount)
+        await MainActor.run {
+            presenter.listener = self
+        }
+    }
+
+    func willResignActive() async {
+        let presenter = self.presenter
+        await MainActor.run {
+            presenter.listener = nil
+        }
+    }
+
+    // MARK: - CounterNapkinPresentableListener
+
+    func didTapIncrement() async {
+        count += 1
+        await presenter.update(count: count)
+    }
+
+    func didTapDecrement() async {
+        count -= 1
+        await presenter.update(count: count)
+    }
+
+    func didTapDone() async {
+        await listener?.counterDidFinish()
+    }
+}

--- a/Examples/LaunchNapkin/CounterNapkinRouter.swift
+++ b/Examples/LaunchNapkin/CounterNapkinRouter.swift
@@ -1,0 +1,27 @@
+//
+//  CounterNapkinRouter.swift
+//  napkin
+//
+//  Created by nonplus on 5/4/26.
+//
+
+import napkin
+
+@MainActor
+protocol CounterNapkinViewControllable: ViewControllable {
+    // Declare methods the router invokes to manipulate the view hierarchy.
+}
+
+@MainActor
+final class CounterNapkinRouter:
+    ViewableRouter<CounterNapkinInteractor, CounterNapkinViewControllable>,
+    CounterNapkinRouting
+{
+
+    override init(
+        interactor: CounterNapkinInteractor,
+        viewController: CounterNapkinViewControllable
+    ) {
+        super.init(interactor: interactor, viewController: viewController)
+    }
+}

--- a/Examples/LaunchNapkin/CounterNapkinView.swift
+++ b/Examples/LaunchNapkin/CounterNapkinView.swift
@@ -1,0 +1,52 @@
+//
+//  CounterNapkinView.swift
+//  napkin
+//
+//  Created by nonplus on 5/4/26.
+//
+
+import SwiftUI
+import napkin
+
+struct CounterNapkinView: View {
+    var count: Int = 0
+    weak var listener: CounterNapkinPresentableListener?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Text("\(count)")
+                    .font(.system(size: 80, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                    .padding(.top, 60)
+
+                HStack(spacing: 16) {
+                    Button("-") {
+                        dispatch { [listener] in await listener?.didTapDecrement() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+
+                    Button("+") {
+                        dispatch { [listener] in await listener?.didTapIncrement() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                }
+                Spacer()
+            }
+            .navigationTitle("Counter")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dispatch { [listener] in await listener?.didTapDone() }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    CounterNapkinView()
+}

--- a/Examples/LaunchNapkin/LaunchNapkinBuilder.swift
+++ b/Examples/LaunchNapkin/LaunchNapkinBuilder.swift
@@ -17,6 +17,10 @@ final class LaunchNapkinComponent: Component<LaunchNapkinDependency>, @unchecked
     // Declare 'fileprivate' dependencies that are only used by this napkin.
 }
 
+// The LaunchNapkin's component bridges its child napkins' (empty) dependency
+// requirements; both child Dependency protocols are empty so this is trivial.
+extension LaunchNapkinComponent: CounterNapkinDependency, QuoteNapkinDependency {}
+
 // MARK: - Builder
 
 protocol LaunchNapkinBuildable: Buildable {
@@ -32,11 +36,17 @@ final class LaunchNapkinBuilder: Builder<LaunchNapkinDependency>, LaunchNapkinBu
     @MainActor
     func build(withListener listener: LaunchNapkinListener) async -> LaunchNapkinRouting {
         let component = LaunchNapkinComponent(dependency: dependency)
-        _ = component
+        let counterBuilder = CounterNapkinBuilder(dependency: component)
+        let quoteBuilder = QuoteNapkinBuilder(dependency: component)
         let viewController = LaunchNapkinViewController()
         let interactor = LaunchNapkinInteractor(presenter: viewController)
         await interactor.set(listener: listener)
-        let router = LaunchNapkinRouter(interactor: interactor, viewController: viewController)
+        let router = LaunchNapkinRouter(
+            interactor: interactor,
+            viewController: viewController,
+            counterBuilder: counterBuilder,
+            quoteBuilder: quoteBuilder
+        )
         await interactor.set(router: router)
         return router
     }

--- a/Examples/LaunchNapkin/LaunchNapkinHostingViewController.swift
+++ b/Examples/LaunchNapkin/LaunchNapkinHostingViewController.swift
@@ -12,7 +12,8 @@ protocol LaunchNapkinPresentableListener: AnyObject, Sendable {
     // Declare properties and methods that the view controller can invoke to perform
     // business logic, such as signIn(). This protocol is implemented by the corresponding
     // interactor actor; methods are async.
-    func didTap() async
+    func didTapShowCounter() async
+    func didTapShowQuote() async
 }
 
 #if canImport(UIKit)

--- a/Examples/LaunchNapkin/LaunchNapkinInteractor.swift
+++ b/Examples/LaunchNapkin/LaunchNapkinInteractor.swift
@@ -8,10 +8,14 @@
 import napkin
 
 @MainActor
-protocol LaunchNapkinRouting: LaunchRouting {
+protocol LaunchNapkinRouting: LaunchRouting, Sendable {
     // Declare methods the interactor can invoke to manage sub-tree via the router.
     // Routing methods are async because the router is @MainActor and is called from
     // the interactor actor.
+    func routeToCounter() async
+    func routeBackFromCounter() async
+    func routeToQuote() async
+    func routeBackFromQuote() async
 }
 
 protocol LaunchNapkinPresentable: Presentable, Sendable {
@@ -25,7 +29,12 @@ protocol LaunchNapkinListener: AnyObject, Sendable {
     // Listener methods are async because the parent's interactor is an actor.
 }
 
-final actor LaunchNapkinInteractor: PresentableInteractable, LaunchNapkinPresentableListener {
+final actor LaunchNapkinInteractor:
+    PresentableInteractable,
+    LaunchNapkinPresentableListener,
+    CounterNapkinListener,
+    QuoteNapkinListener
+{
 
     nonisolated let lifecycle = InteractorLifecycle()
     nonisolated let presenter: LaunchNapkinPresentable
@@ -48,16 +57,38 @@ final actor LaunchNapkinInteractor: PresentableInteractable, LaunchNapkinPresent
     }
 
     func didBecomeActive() async {
-        // Implement business logic here.
+        let presenter = self.presenter
+        await MainActor.run {
+            presenter.listener = self
+        }
     }
 
     func willResignActive() async {
-        // Pause any business logic.
+        let presenter = self.presenter
+        await MainActor.run {
+            presenter.listener = nil
+        }
     }
 
     // MARK: - LaunchNapkinPresentableListener
 
-    func didTap() async {
-        // Handle the view's tap event.
+    func didTapShowCounter() async {
+        await router?.routeToCounter()
+    }
+
+    func didTapShowQuote() async {
+        await router?.routeToQuote()
+    }
+
+    // MARK: - CounterNapkinListener
+
+    func counterDidFinish() async {
+        await router?.routeBackFromCounter()
+    }
+
+    // MARK: - QuoteNapkinListener
+
+    func quoteDidFinish() async {
+        await router?.routeBackFromQuote()
     }
 }

--- a/Examples/LaunchNapkin/LaunchNapkinRouter.swift
+++ b/Examples/LaunchNapkin/LaunchNapkinRouter.swift
@@ -18,8 +18,65 @@ final class LaunchNapkinRouter:
     LaunchNapkinRouting
 {
 
-    // Constructor inject child builder protocols to allow building children.
-    override init(interactor: LaunchNapkinInteractor, viewController: LaunchNapkinViewControllable) {
+    private let counterBuilder: CounterNapkinBuildable
+    private let quoteBuilder: QuoteNapkinBuildable
+    private var counterRouter: CounterNapkinRouting?
+    private var quoteRouter: QuoteNapkinRouting?
+
+    init(
+        interactor: LaunchNapkinInteractor,
+        viewController: LaunchNapkinViewControllable,
+        counterBuilder: CounterNapkinBuildable,
+        quoteBuilder: QuoteNapkinBuildable
+    ) {
+        self.counterBuilder = counterBuilder
+        self.quoteBuilder = quoteBuilder
         super.init(interactor: interactor, viewController: viewController)
+    }
+
+    // MARK: - LaunchNapkinRouting
+
+    func routeToCounter() async {
+        guard counterRouter == nil else { return }
+        let router = await counterBuilder.build(withListener: interactor)
+        counterRouter = router
+        await attachChild(router)
+        #if canImport(UIKit)
+        viewController.uiviewController.present(
+            router.viewControllable.uiviewController,
+            animated: true
+        )
+        #endif
+    }
+
+    func routeBackFromCounter() async {
+        guard let router = counterRouter else { return }
+        counterRouter = nil
+        #if canImport(UIKit)
+        router.viewControllable.uiviewController.dismiss(animated: true)
+        #endif
+        await detachChild(router)
+    }
+
+    func routeToQuote() async {
+        guard quoteRouter == nil else { return }
+        let router = await quoteBuilder.build(withListener: interactor)
+        quoteRouter = router
+        await attachChild(router)
+        #if canImport(UIKit)
+        viewController.uiviewController.present(
+            router.viewControllable.uiviewController,
+            animated: true
+        )
+        #endif
+    }
+
+    func routeBackFromQuote() async {
+        guard let router = quoteRouter else { return }
+        quoteRouter = nil
+        #if canImport(UIKit)
+        router.viewControllable.uiviewController.dismiss(animated: true)
+        #endif
+        await detachChild(router)
     }
 }

--- a/Examples/LaunchNapkin/LaunchNapkinView.swift
+++ b/Examples/LaunchNapkin/LaunchNapkinView.swift
@@ -15,9 +15,15 @@ struct LaunchNapkinView: View {
     var body: some View {
         VStack(spacing: 16) {
             Text("Hello, World!")
-            Button("Tap") {
-                dispatch { [listener] in await listener?.didTap() }
+                .font(.title2)
+            Button("Show Counter") {
+                dispatch { [listener] in await listener?.didTapShowCounter() }
             }
+            .buttonStyle(.borderedProminent)
+            Button("Show Quote") {
+                dispatch { [listener] in await listener?.didTapShowQuote() }
+            }
+            .buttonStyle(.borderedProminent)
         }
     }
 }

--- a/Examples/LaunchNapkin/QuoteNapkinBuilder.swift
+++ b/Examples/LaunchNapkin/QuoteNapkinBuilder.swift
@@ -1,0 +1,47 @@
+//
+//  QuoteNapkinBuilder.swift
+//  napkin
+//
+//  Created by nonplus on 5/4/26.
+//
+
+import napkin
+
+protocol QuoteNapkinDependency: Dependency {
+    // Declare the set of dependencies required by this napkin, but cannot be
+    // created by this napkin.
+}
+
+final class QuoteNapkinComponent: Component<QuoteNapkinDependency>, @unchecked Sendable {
+
+    // Declare 'fileprivate' dependencies that are only used by this napkin.
+}
+
+// MARK: - Builder
+
+protocol QuoteNapkinBuildable: Buildable {
+    @MainActor func build(withListener listener: QuoteNapkinListener) async -> QuoteNapkinRouting
+}
+
+final class QuoteNapkinBuilder:
+    Builder<QuoteNapkinDependency>,
+    QuoteNapkinBuildable,
+    @unchecked Sendable
+{
+
+    override init(dependency: QuoteNapkinDependency) {
+        super.init(dependency: dependency)
+    }
+
+    @MainActor
+    func build(withListener listener: QuoteNapkinListener) async -> QuoteNapkinRouting {
+        let component = QuoteNapkinComponent(dependency: dependency)
+        _ = component
+        let viewController = QuoteNapkinViewController()
+        let interactor = QuoteNapkinInteractor(presenter: viewController)
+        await interactor.set(listener: listener)
+        let router = QuoteNapkinRouter(interactor: interactor, viewController: viewController)
+        await interactor.set(router: router)
+        return router
+    }
+}

--- a/Examples/LaunchNapkin/QuoteNapkinHostingViewController.swift
+++ b/Examples/LaunchNapkin/QuoteNapkinHostingViewController.swift
@@ -1,0 +1,64 @@
+//
+//  QuoteNapkinHostingViewController.swift
+//  napkin
+//
+//  Created by nonplus on 5/4/26.
+//
+
+import napkin
+import SwiftUI
+
+protocol QuoteNapkinPresentableListener: AnyObject, Sendable {
+    func didTapNewQuote() async
+    func didTapDone() async
+}
+
+#if canImport(UIKit)
+@MainActor
+final class QuoteNapkinViewController:
+    UIHostingController<QuoteNapkinView>,
+    QuoteNapkinPresentable
+{
+
+    weak var listener: QuoteNapkinPresentableListener? {
+        didSet { rootView.listener = listener }
+    }
+
+    init() {
+        super.init(rootView: QuoteNapkinView())
+    }
+
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(quote: String) async {
+        rootView.quote = quote
+    }
+}
+#elseif canImport(AppKit)
+@MainActor
+final class QuoteNapkinViewController:
+    NSHostingController<QuoteNapkinView>,
+    QuoteNapkinPresentable
+{
+
+    weak var listener: QuoteNapkinPresentableListener? {
+        didSet { rootView.listener = listener }
+    }
+
+    init() {
+        super.init(rootView: QuoteNapkinView())
+    }
+
+    @MainActor required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(quote: String) async {
+        rootView.quote = quote
+    }
+}
+#endif
+
+extension QuoteNapkinViewController: QuoteNapkinViewControllable {}

--- a/Examples/LaunchNapkin/QuoteNapkinInteractor.swift
+++ b/Examples/LaunchNapkin/QuoteNapkinInteractor.swift
@@ -1,0 +1,82 @@
+//
+//  QuoteNapkinInteractor.swift
+//  napkin
+//
+//  Created by nonplus on 5/4/26.
+//
+
+import napkin
+
+@MainActor
+protocol QuoteNapkinRouting: ViewableRouting, Sendable {
+    // Declare methods the interactor can invoke to manage sub-tree via the router.
+}
+
+protocol QuoteNapkinPresentable: Presentable, Sendable {
+    @MainActor var listener: QuoteNapkinPresentableListener? { get set }
+    func update(quote: String) async
+}
+
+protocol QuoteNapkinListener: AnyObject, Sendable {
+    func quoteDidFinish() async
+}
+
+final actor QuoteNapkinInteractor: PresentableInteractable, QuoteNapkinPresentableListener {
+
+    nonisolated let lifecycle = InteractorLifecycle()
+    nonisolated let presenter: QuoteNapkinPresentable
+
+    weak var router: QuoteNapkinRouting?
+    weak var listener: QuoteNapkinListener?
+
+    private let quotes: [String] = [
+        "Programs must be written for people to read, and only incidentally for machines to execute.",
+        "Premature optimization is the root of all evil.",
+        "There are 2 hard things in computer science: cache invalidation, naming things, and off-by-one errors."
+    ]
+
+    init(presenter: QuoteNapkinPresentable) {
+        self.presenter = presenter
+    }
+
+    func set(router: QuoteNapkinRouting?) {
+        self.router = router
+    }
+
+    func set(listener: QuoteNapkinListener?) {
+        self.listener = listener
+    }
+
+    func didBecomeActive() async {
+        let quote = pickQuote()
+        let presenter = self.presenter
+        await presenter.update(quote: quote)
+        await MainActor.run {
+            presenter.listener = self
+        }
+    }
+
+    func willResignActive() async {
+        let presenter = self.presenter
+        await MainActor.run {
+            presenter.listener = nil
+        }
+    }
+
+    // MARK: - QuoteNapkinPresentableListener
+
+    func didTapNewQuote() async {
+        let quote = pickQuote()
+        await presenter.update(quote: quote)
+    }
+
+    func didTapDone() async {
+        await listener?.quoteDidFinish()
+    }
+
+    // MARK: - Private
+
+    private func pickQuote() -> String {
+        quotes.randomElement() ?? ""
+    }
+}

--- a/Examples/LaunchNapkin/QuoteNapkinRouter.swift
+++ b/Examples/LaunchNapkin/QuoteNapkinRouter.swift
@@ -1,0 +1,27 @@
+//
+//  QuoteNapkinRouter.swift
+//  napkin
+//
+//  Created by nonplus on 5/4/26.
+//
+
+import napkin
+
+@MainActor
+protocol QuoteNapkinViewControllable: ViewControllable {
+    // Declare methods the router invokes to manipulate the view hierarchy.
+}
+
+@MainActor
+final class QuoteNapkinRouter:
+    ViewableRouter<QuoteNapkinInteractor, QuoteNapkinViewControllable>,
+    QuoteNapkinRouting
+{
+
+    override init(
+        interactor: QuoteNapkinInteractor,
+        viewController: QuoteNapkinViewControllable
+    ) {
+        super.init(interactor: interactor, viewController: viewController)
+    }
+}

--- a/Examples/LaunchNapkin/QuoteNapkinView.swift
+++ b/Examples/LaunchNapkin/QuoteNapkinView.swift
@@ -1,0 +1,43 @@
+//
+//  QuoteNapkinView.swift
+//  napkin
+//
+//  Created by nonplus on 5/4/26.
+//
+
+import SwiftUI
+import napkin
+
+struct QuoteNapkinView: View {
+    var quote: String = ""
+    weak var listener: QuoteNapkinPresentableListener?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+                Text(quote)
+                    .font(.title3)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+                Button("New Quote") {
+                    dispatch { [listener] in await listener?.didTapNewQuote() }
+                }
+                .buttonStyle(.borderedProminent)
+                Spacer()
+            }
+            .navigationTitle("Quote")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        dispatch { [listener] in await listener?.didTapDone() }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    QuoteNapkinView()
+}


### PR DESCRIPTION
## Summary
- Grow `Examples/LaunchNapkinApp` from a single napkin to a real 3-napkin tree: LaunchNapkin -> CounterNapkin, LaunchNapkin -> QuoteNapkin.
- Demonstrates the full napkin pattern set: builder/component/interactor/router/presenter/view, modal presentation, parent/child wiring, listener callbacks, and routing across `@MainActor` and actor isolation.
- LaunchNapkinComponent now extends both child Dependency protocols (both empty), so the builder can pass it directly to `CounterNapkinBuilder` / `QuoteNapkinBuilder`. The LaunchNapkin interactor conforms to `CounterNapkinListener` and `QuoteNapkinListener` and dispatches to `router?.routeBack...` on finish.
- Routing protocols are `@MainActor & Sendable` so the actor-isolated interactor can `await router?.routeTo...()` without Swift 6 sending-non-Sendable errors.

## Files
- 10 new files (5 each for CounterNapkin and QuoteNapkin: Builder, Interactor, Router, HostingViewController, View)
- 5 modified files in LaunchNapkin (Builder, Interactor, Router, View, HostingViewController)

## Test plan
- [x] `swift build` clean
- [x] `swift test` — 42 tests pass
- [x] `xcodebuild` for iPhone 17 / iOS latest succeeds
- [x] Runtime on iPhone 17 simulator: launch screen shows two buttons; Counter modal renders ("0", +, -, Done); Quote modal renders ("Premature optimization is the root of all evil.", New Quote, Done) — `didBecomeActive` listener wiring confirmed
- [x] Console output: no isolation / sendable / Main Thread Checker / data-race warnings

Screenshots captured locally at `/tmp/napkin-test-app-v2-{launch,counter,quote}.png` (verified visually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)