### PR TITLE
Add accessibility identifiers and UI test target to LaunchNapkinApp

### DIFF
--- a/Examples/LaunchNapkin/AccessibilityIdentifiers.swift
+++ b/Examples/LaunchNapkin/AccessibilityIdentifiers.swift
@@ -1,0 +1,35 @@
+//
+//  AccessibilityIdentifiers.swift
+//  napkin example
+//
+//  Centralized accessibility identifiers for UI testing. Shared between the
+//  app target (which sets the identifiers via `.accessibilityIdentifier(...)`)
+//  and the UI test target (which queries them via `app.buttons[...]` etc.).
+//
+//  Identifiers are namespaced by napkin so tests can reference, e.g.,
+//  `NapkinAccessibility.Launch.showCounterButton`.
+//
+
+import Foundation
+
+public enum NapkinAccessibility {
+
+    public enum Launch {
+        public static let greeting = "launch.greeting"
+        public static let showCounterButton = "launch.showCounterButton"
+        public static let showQuoteButton = "launch.showQuoteButton"
+    }
+
+    public enum Counter {
+        public static let countLabel = "counter.countLabel"
+        public static let incrementButton = "counter.incrementButton"
+        public static let decrementButton = "counter.decrementButton"
+        public static let doneButton = "counter.doneButton"
+    }
+
+    public enum Quote {
+        public static let quoteLabel = "quote.quoteLabel"
+        public static let newQuoteButton = "quote.newQuoteButton"
+        public static let doneButton = "quote.doneButton"
+    }
+}

--- a/Examples/LaunchNapkin/CounterNapkinView.swift
+++ b/Examples/LaunchNapkin/CounterNapkinView.swift
@@ -19,6 +19,7 @@ struct CounterNapkinView: View {
                     .font(.system(size: 80, weight: .semibold, design: .rounded))
                     .monospacedDigit()
                     .padding(.top, 60)
+                    .accessibilityIdentifier(NapkinAccessibility.Counter.countLabel)
 
                 HStack(spacing: 16) {
                     Button("-") {
@@ -26,12 +27,14 @@ struct CounterNapkinView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
+                    .accessibilityIdentifier(NapkinAccessibility.Counter.decrementButton)
 
                     Button("+") {
                         dispatch { [listener] in await listener?.didTapIncrement() }
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
+                    .accessibilityIdentifier(NapkinAccessibility.Counter.incrementButton)
                 }
                 Spacer()
             }
@@ -41,6 +44,7 @@ struct CounterNapkinView: View {
                     Button("Done") {
                         dispatch { [listener] in await listener?.didTapDone() }
                     }
+                    .accessibilityIdentifier(NapkinAccessibility.Counter.doneButton)
                 }
             }
         }

--- a/Examples/LaunchNapkin/LaunchNapkinView.swift
+++ b/Examples/LaunchNapkin/LaunchNapkinView.swift
@@ -16,14 +16,17 @@ struct LaunchNapkinView: View {
         VStack(spacing: 16) {
             Text("Hello, World!")
                 .font(.title2)
+                .accessibilityIdentifier(NapkinAccessibility.Launch.greeting)
             Button("Show Counter") {
                 dispatch { [listener] in await listener?.didTapShowCounter() }
             }
             .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier(NapkinAccessibility.Launch.showCounterButton)
             Button("Show Quote") {
                 dispatch { [listener] in await listener?.didTapShowQuote() }
             }
             .buttonStyle(.borderedProminent)
+            .accessibilityIdentifier(NapkinAccessibility.Launch.showQuoteButton)
         }
     }
 }

--- a/Examples/LaunchNapkin/QuoteNapkinView.swift
+++ b/Examples/LaunchNapkin/QuoteNapkinView.swift
@@ -20,10 +20,12 @@ struct QuoteNapkinView: View {
                     .font(.title3)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 32)
+                    .accessibilityIdentifier(NapkinAccessibility.Quote.quoteLabel)
                 Button("New Quote") {
                     dispatch { [listener] in await listener?.didTapNewQuote() }
                 }
                 .buttonStyle(.borderedProminent)
+                .accessibilityIdentifier(NapkinAccessibility.Quote.newQuoteButton)
                 Spacer()
             }
             .navigationTitle("Quote")
@@ -32,6 +34,7 @@ struct QuoteNapkinView: View {
                     Button("Done") {
                         dispatch { [listener] in await listener?.didTapDone() }
                     }
+                    .accessibilityIdentifier(NapkinAccessibility.Quote.doneButton)
                 }
             }
         }

--- a/Examples/LaunchNapkinApp/UITests/LaunchNapkinAppUITests.swift
+++ b/Examples/LaunchNapkinApp/UITests/LaunchNapkinAppUITests.swift
@@ -1,0 +1,79 @@
+//
+//  LaunchNapkinAppUITests.swift
+//  napkin example UI tests
+//
+//  Demonstrates how to drive the napkin example app via XCUITest using the
+//  identifiers defined in AccessibilityIdentifiers.swift. Mirrors how a real
+//  consumer would write end-to-end tests against an app built with napkin.
+//
+
+import XCTest
+
+final class LaunchNapkinAppUITests: XCTestCase {
+
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+    }
+
+    func testLaunchScreenShowsBothNapkinEntryButtons() {
+        let greeting = app.staticTexts[NapkinAccessibility.Launch.greeting]
+        XCTAssertTrue(greeting.waitForExistence(timeout: 5))
+        XCTAssertEqual(greeting.label, "Hello, World!")
+
+        XCTAssertTrue(app.buttons[NapkinAccessibility.Launch.showCounterButton].exists)
+        XCTAssertTrue(app.buttons[NapkinAccessibility.Launch.showQuoteButton].exists)
+    }
+
+    func testCounterIncrementsAndDecrements() {
+        app.buttons[NapkinAccessibility.Launch.showCounterButton].tap()
+
+        let count = app.staticTexts[NapkinAccessibility.Counter.countLabel]
+        XCTAssertTrue(count.waitForExistence(timeout: 5))
+        XCTAssertEqual(count.label, "0")
+
+        app.buttons[NapkinAccessibility.Counter.incrementButton].tap()
+        app.buttons[NapkinAccessibility.Counter.incrementButton].tap()
+        XCTAssertEqual(count.label, "2")
+
+        app.buttons[NapkinAccessibility.Counter.decrementButton].tap()
+        XCTAssertEqual(count.label, "1")
+
+        app.buttons[NapkinAccessibility.Counter.doneButton].tap()
+        // Back at the launch screen
+        XCTAssertTrue(
+            app.buttons[NapkinAccessibility.Launch.showCounterButton]
+                .waitForExistence(timeout: 5)
+        )
+    }
+
+    func testQuoteRerollsAndDismisses() {
+        app.buttons[NapkinAccessibility.Launch.showQuoteButton].tap()
+
+        let quote = app.staticTexts[NapkinAccessibility.Quote.quoteLabel]
+        XCTAssertTrue(quote.waitForExistence(timeout: 5))
+        let initialQuote = quote.label
+        XCTAssertFalse(initialQuote.isEmpty)
+
+        // Reroll a few times — at least one of the new values should differ from
+        // the initial value (the quotes array has more than one entry).
+        var sawDifferent = false
+        for _ in 0..<10 {
+            app.buttons[NapkinAccessibility.Quote.newQuoteButton].tap()
+            if quote.label != initialQuote {
+                sawDifferent = true
+                break
+            }
+        }
+        XCTAssertTrue(sawDifferent, "New Quote button should produce a different quote within 10 taps")
+
+        app.buttons[NapkinAccessibility.Quote.doneButton].tap()
+        XCTAssertTrue(
+            app.buttons[NapkinAccessibility.Launch.showQuoteButton]
+                .waitForExistence(timeout: 5)
+        )
+    }
+}

--- a/Examples/LaunchNapkinApp/project.yml
+++ b/Examples/LaunchNapkinApp/project.yml
@@ -42,3 +42,20 @@ targets:
         ENABLE_PREVIEWS: "YES"
         GENERATE_INFOPLIST_FILE: "NO"
         PRODUCT_BUNDLE_IDENTIFIER: com.napkin.example.LaunchNapkinApp
+
+  LaunchNapkinAppUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources:
+      - path: UITests
+      - path: ../LaunchNapkin/AccessibilityIdentifiers.swift
+    dependencies:
+      - target: LaunchNapkinApp
+    settings:
+      base:
+        IPHONEOS_DEPLOYMENT_TARGET: "26.0"
+        SWIFT_VERSION: "6.2"
+        TARGETED_DEVICE_FAMILY: "1,2"
+        GENERATE_INFOPLIST_FILE: "YES"
+        PRODUCT_BUNDLE_IDENTIFIER: com.napkin.example.LaunchNapkinAppUITests
+        TEST_TARGET_NAME: LaunchNapkinApp

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -23,7 +23,29 @@ Verified working on iPhone 17 / iOS 26.4.1 simulator: app launches, the `LaunchR
 
 ### What it does
 
-Loads a `LaunchNapkinHostingViewController` (a SwiftUI view wrapped in a `UIHostingController`) at the window root via napkin's `LaunchRouter`. Tap the button to fire a presenter -> listener event into the actor-isolated `LaunchNapkinInteractor`.
+Loads a `LaunchNapkinHostingViewController` (a SwiftUI view wrapped in a `UIHostingController`) at the window root via napkin's `LaunchRouter`. The launch screen presents two child napkins modally — a `CounterNapkin` (demonstrates `@Observable` presenter state and listener-driven dismissal) and a `QuoteNapkin` (demonstrates simpler napkin shape and another listener callback). Together the three napkins exercise the full builder/component/interactor/router/presenter/view stack with actor isolation across the boundary.
+
+### UI tests
+
+The `LaunchNapkinAppUITests` target shows how to write XCUITest tests against an app built with napkin. Every interactive element is tagged with a stable identifier from the shared `AccessibilityIdentifiers.swift` file (namespaced as `NapkinAccessibility.Launch.*`, `.Counter.*`, `.Quote.*`), so tests can refer to elements by symbolic name instead of fragile label strings:
+
+```swift
+app.buttons[NapkinAccessibility.Launch.showCounterButton].tap()
+app.buttons[NapkinAccessibility.Counter.incrementButton].tap()
+let count = app.staticTexts[NapkinAccessibility.Counter.countLabel]
+XCTAssertEqual(count.label, "1")
+```
+
+Run them with:
+
+```sh
+xcodebuild -project Examples/LaunchNapkinApp/LaunchNapkinApp.xcodeproj \
+  -scheme LaunchNapkinApp \
+  -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" \
+  test
+```
+
+Important: when adding identifiers to a SwiftUI view tree, **don't put `.accessibilityIdentifier(...)` on the parent container** — SwiftUI propagates it to descendants and overrides their own identifiers. Apply it directly to each interactive element (`Text`, `Button`, etc.).
 
 ### iCloud Drive note
 


### PR DESCRIPTION
## Summary

Adds stable accessibility identifiers to every interactive element in the three example napkins (Launch, Counter, Quote) and a new `LaunchNapkinAppUITests` target showing how to write XCUITest tests against an app built with napkin.

- **`Examples/LaunchNapkin/AccessibilityIdentifiers.swift`** — new file defining a `NapkinAccessibility` enum with namespaced static strings (`NapkinAccessibility.Launch.showCounterButton`, etc.). Shared between the app target and the UI test target via project.yml `sources`.
- **Views** — every `Button` and salient `Text` is tagged with `.accessibilityIdentifier(NapkinAccessibility.…)`. Identifiers are applied at the *leaf* level only — putting them on a parent VStack overrode the children's identifiers (a SwiftUI propagation behavior surfaced during the first test run).
- **`LaunchNapkinAppUITests`** — new test target with three sample tests: launch-screen smoke check, counter increment/decrement, quote reroll-and-dismiss. All three pass on iPhone 17 / iOS latest simulator.
- **`Examples/README.md`** — documents the test target and the parent-identifier propagation gotcha so consumers don't trip over it.

## Test plan

- [x] `xcodebuild -scheme LaunchNapkinApp -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" test` passes (3/3 UI tests succeed)
- [x] App builds cleanly for iOS 26.4 simulator
- [x] No Swift 6 isolation/sendable warnings introduced
- [x] `swift build` and `swift test` for the framework target unaffected (still 42/42 passing)