### PR TITLE
Publish DocC to GitHub Pages

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,59 @@
+name: Documentation
+on:
+  push:
+    branches:
+    - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one Pages deploy at a time. New deploys cancel in-flight ones.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    name: Build & Deploy
+    runs-on: macos-26
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26'
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build DocC
+        # --hosting-base-path is just the repo name; the resulting URL is
+        # https://wikipediabrown.github.io/napkin/documentation/napkin/
+        # The index.html redirect lets the bare /napkin/ URL land on the
+        # module page (DocC's static-hosting transform doesn't generate one).
+        run: |
+          swift package --allow-writing-to-directory ./docs \
+            generate-documentation \
+            --target napkin \
+            --disable-indexing \
+            --transform-for-static-hosting \
+            --hosting-base-path napkin \
+            --output-path ./docs
+          echo '<script>window.location.href += "/documentation/napkin"</script>' > docs/index.html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Adds a Documentation workflow that builds the napkin DocC catalog and deploys to GitHub Pages on every push to \`main\`. Site URL:

> **https://wikipediabrown.github.io/napkin/documentation/napkin/**

## What's in the workflow

- Runs on \`macos-26\` with Xcode 26 (matches the rest of napkin's CI)
- Calls \`swift package generate-documentation --target napkin --disable-indexing --transform-for-static-hosting --hosting-base-path napkin --output-path ./docs\` — the canonical Apple-recommended invocation (verified against [swiftlang/swift-docc-plugin](https://github.com/swiftlang/swift-docc-plugin)'s own \`Publishing to GitHub Pages\` article and the \`bin/update-gh-pages-documentation-site\` reference script)
- Writes a one-line \`index.html\` redirect at \`docs/\` so the bare site root bounces to \`/documentation/napkin/\` (DocC's static-hosting transform doesn't ship one)
- Uploads via \`actions/upload-pages-artifact@v3\` and deploys via \`actions/deploy-pages@v4\` — modern GitHub-recommended Pages-as-Actions flow, no \`gh-pages\` branch needed

## Why hand-rolled

There is **no default/turnkey path** for Swift Package → DocC → Pages:
- GitHub's starter-workflows repo has Pages templates for Jekyll, Hugo, Astro, Next.js, mdbook — none for Swift/DocC.
- swift-docc-plugin ships no reusable workflow, just a shell script demonstrating the legacy gh-pages-branch flow.
- Marketplace actions like \`fwcd/swift-docc-action\` exist but are unmaintained (last release April 2022).

So Apple's prose guidance + the modern \`deploy-pages\` action is the cleanest path.

## Pages config

Already enabled with \`build_type=workflow\` via:
\`gh api -X POST repos/WikipediaBrown/napkin/pages -f build_type=workflow\`

## Test plan

- [ ] PR check (Tests / unit + UI) passes — Documentation workflow itself only fires on push to main, not on PRs
- [ ] After merge to main, Documentation workflow runs and deploys
- [ ] \`https://wikipediabrown.github.io/napkin/\` redirects to \`/documentation/napkin/\` and renders the napkin landing article