### PR TITLE
Run Documentation workflow after Release

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,8 +1,12 @@
 name: Documentation
 on:
-  push:
-    branches:
-    - main
+  # Run after the Release workflow finishes, so `git describe --tags` picks up
+  # the freshly-pushed release tag instead of racing with it (the bug that
+  # left 2.0.7 in the footer while Release was publishing 2.0.8 in parallel).
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Documentation stamps the homepage footer with `git describe --tags --abbrev=0`. Both workflows fire on push to main and ran in parallel — Documentation saw the previous tag, Release published the new one. Footer was always one version behind (just saw 2.0.7 stamped while 2.0.8 was being published).

Switch Documentation's trigger from `push: branches: [main]` to `workflow_run: workflows: [Release]` so it runs after Release completes. Manual `workflow_dispatch` still works.
