### PR TITLE
Fix actions/checkout case-collision in Release workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -29,6 +29,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Narrow remote refspec
+        # Override `remote.origin.fetch` so subsequent `git fetch --tags`
+        # calls (run by fastlane's `git_pull(only_tags: true)` inside
+        # `create_next_version`) only target `main` instead of all
+        # branches. On macos-26 APFS (case-insensitive), the long-stale
+        # `CI` branch (file at .git/refs/remotes/origin/CI) collides with
+        # `ci/...` namespaced branches (which need a directory at
+        # .git/refs/remotes/origin/ci/), failing with
+        # `error: some local refs could not be updated`. The narrowed
+        # refspec sidesteps the collision entirely.
+        run: |
+          git config --local remote.origin.fetch '+refs/heads/main:refs/remotes/origin/main'
       - name: Select Xcode
         # Plain Apple tooling, no third-party action. Glob picks the highest
         # Xcode 26.x.y installed on the runner so a runner-image refresh


### PR DESCRIPTION
## Summary

- Sibling fix to PR #110. Same APFS case-collision, different workflow.
- Release workflow's fastlane `release_to_github` lane calls `git_pull(only_tags: true)` which runs `git fetch --tags`. That uses the configured remote refspec (default `+refs/heads/*:refs/remotes/origin/*`) plus `--tags`, triggering the same bulk-branch fetch that fails on macos-26 with `error: some local refs could not be updated`.
- Fix: narrow `remote.origin.fetch` to `main` only after checkout. Subsequent `git fetch --tags` then only fetches main + tags, no other branches, no collision.

## Why this matters now

The Release run on commit `911227b` (homepage redesign merge to main) failed at the `Create Release Tag` step with this exact error, which is why no `2.0.12` tag exists and the homepage redesign never deployed.

## Test plan

- [ ] CI passes on this PR (Tests.yml runs against develop)
- [ ] After merge to develop → merge develop → main, the auto-triggered Release workflow completes without the refspec error
- [ ] A new release tag is published
- [ ] workflow_run cascade fires Documentation, which deploys the redesigned homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)