### PR TITLE
Fix Documentation workflow tag fetch + force main checkout

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -30,18 +30,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Shallow + tags. Deliberately NOT `fetch-depth: 0` here: that
-          # triggers a bulk fetch of every remote branch via refspec
-          # `+refs/heads/*:refs/remotes/origin/*`. On macos-26 the runner
-          # filesystem is APFS (case-insensitive), so the long-stale `CI`
-          # branch (file at .git/refs/remotes/origin/CI) collides with
-          # `ci/...` namespaced branches (which need a directory at
-          # .git/refs/remotes/origin/ci/) and the fetch dies with
-          # `[new branch] CI -> origin/CI (unable to update local ref)`.
-          # `fetch-tags: true` still pulls all tag refs + their commits,
-          # which is all the homepage stamp + versioned docs loop need.
+          # Always deploy from main. `workflow_run` fires Documentation
+          # in the default branch's context (develop), but main is the
+          # source of truth for the public site — we don't want develop
+          # changes leaking out before they're merged to main.
+          ref: main
+          # Shallow. Deliberately NOT `fetch-depth: 0`: that triggers a
+          # bulk fetch of every remote branch via refspec
+          # `+refs/heads/*:refs/remotes/origin/*`. On macos-26 APFS
+          # (case-insensitive), the long-stale `CI` branch (file) collides
+          # with `ci/...` namespaced branches (would-be directory) and
+          # the fetch dies with `error: some local refs could not be updated`.
+          # We intentionally do NOT set `fetch-tags: true` here — empirically
+          # the option is silently dropped on shallow checkouts (the fetch
+          # log shows no `--tags` flag). Tags are fetched explicitly below
+          # with a narrowed refspec.
           fetch-depth: 1
-          fetch-tags: true
+
+      - name: Fetch tags
+        # Pull all tag refs + their commits ourselves, since actions/checkout's
+        # `fetch-tags: true` doesn't fire on shallow checkouts. Narrow
+        # `remote.origin.fetch` to `main` first so `git fetch --tags`
+        # doesn't try to bulk-fetch every remote branch (which would hit
+        # the same APFS case-collision as `fetch-depth: 0`). `--depth=1`
+        # keeps each tag's history minimal — we only need the tagged
+        # commit's tree to build its docs.
+        run: |
+          git config --local remote.origin.fetch '+refs/heads/main:refs/remotes/origin/main'
+          git fetch --tags --force --depth=1 origin
 
       - name: Select Xcode
         # Plain Apple tooling, no third-party action. Glob picks the highest


### PR DESCRIPTION
## Summary

Two follow-up bugs surfaced after 2.0.12 deployed:

1. **Version stamp broken** — `fetch-tags: true` was silently dropped by `actions/checkout@v4` when combined with `fetch-depth: 1`. The footer rendered as `napkin main` instead of `napkin 2.0.12`. The version dropdown listed only \"main\". Fix: drop `fetch-tags: true` (didn't work) and add an explicit \"Fetch tags\" step that narrows `remote.origin.fetch` to main, then runs `git fetch --tags --depth=1 --force origin`.

2. **Wrong branch deployed** — `workflow_run` fires Documentation in the default branch's context (develop), so checkout pulled develop's SHA. Right now develop and main are identical so the content is correct, but this would silently leak develop work to the public site the next time develop is ahead of main. Fix: explicit `ref: main` on the checkout step.

## Closes/Supersedes

This also obsoletes PR #108 (\"Refresh tags before stamping version\"): the new \"Fetch tags\" step with `--force` makes that PR's intent explicit and the case-collision protection redundant.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge to develop → merge develop → main, Release auto-fires, publishes a new tag, then Documentation auto-fires
- [ ] Documentation logs show: checkout uses `ref: main`, `git fetch --tags --depth=1 --force origin` runs successfully, version resolves to the new tag (not \"main\")
- [ ] Live site footer at https://wikipediabrown.github.io/napkin/ shows the correct \`napkin X.Y.Z\` (linked to that release)
- [ ] Version dropdown shows main + last 5 stable tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)