### PR TITLE
Move site to custom domain getnapkin.to

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -94,7 +94,10 @@ jobs:
 
       - name: Build DocC (latest)
         # Builds the latest version's docs into ./docs/ so the bare URL works:
-        # https://wikipediabrown.github.io/napkin/documentation/napkin/
+        # https://getnapkin.to/documentation/napkin/
+        # With a custom domain, GH Pages serves the artifact at the domain
+        # root (not at /napkin/), so `--hosting-base-path` is omitted —
+        # DocC then emits root-relative links instead of `/napkin/...`.
         # --experimental-enable-custom-templates picks up header.html from
         # the napkin.docc catalog so every docs page gets the same top nav.
         # --source-service / --source-service-base-url / --checkout-path wire
@@ -107,7 +110,6 @@ jobs:
             --target napkin \
             --disable-indexing \
             --transform-for-static-hosting \
-            --hosting-base-path napkin \
             --output-path ./docs \
             --experimental-enable-custom-templates \
             --source-service github \
@@ -116,8 +118,8 @@ jobs:
 
       - name: Build versioned docs
         # Builds main + last 5 stable tags into ./docs/<ref>/ so the URLs
-        #   https://wikipediabrown.github.io/napkin/2.0.8/documentation/napkin/
-        #   https://wikipediabrown.github.io/napkin/main/documentation/napkin/
+        #   https://getnapkin.to/2.0.8/documentation/napkin/
+        #   https://getnapkin.to/main/documentation/napkin/
         # resolve. Best-effort: if an old tag fails to build against the
         # current toolchain we log it and keep going.
         run: |
@@ -148,7 +150,7 @@ jobs:
                 --target napkin \
                 --disable-indexing \
                 --transform-for-static-hosting \
-                --hosting-base-path "napkin/${ref}" \
+                --hosting-base-path "${ref}" \
                 --output-path "docs/${ref}" \
                 --experimental-enable-custom-templates \
                 --source-service github \
@@ -168,7 +170,7 @@ jobs:
       - name: Copy homepage
         # Hand-crafted homepage replaces DocC's missing root index.html with
         # a real landing page (nav bar, hero, feature grid, footer). The
-        # nav links into /napkin/documentation/napkin/ where DocC lives.
+        # nav links into /documentation/napkin/ where DocC lives.
         # __NAPKIN_VERSION__ placeholders in index.html get stamped with the
         # latest git tag, and __VERSION_LINKS__ gets stamped with the list
         # of <option> elements built in the versioned-docs loop above.
@@ -186,7 +188,7 @@ jobs:
           VERSION_LINKS=""
           for ref in $REFS; do
             if [ -d "docs/${ref}" ]; then
-              VERSION_LINKS="${VERSION_LINKS}<option value=\"/napkin/${ref}/documentation/napkin/\">${ref}</option>"
+              VERSION_LINKS="${VERSION_LINKS}<option value=\"/${ref}/documentation/napkin/\">${ref}</option>"
             fi
           done
 
@@ -196,6 +198,13 @@ jobs:
             -e "s/__NAPKIN_VERSION__/${VERSION}/g" \
             -e "s#<!-- __VERSION_LINKS__ -->#${VERSION_LINKS}#g" \
             Tools/site/index.html > docs/index.html
+
+      - name: Write CNAME
+        # GitHub Pages reads docs/CNAME to determine the custom domain.
+        # Putting it in the deploy artifact (rather than setting it via the
+        # Pages API) means the binding is owned by source control and
+        # survives any accidental change to the Pages settings.
+        run: echo "getnapkin.to" > docs/CNAME
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5

--- a/Sources/napkin/napkin.docc/header.html
+++ b/Sources/napkin/napkin.docc/header.html
@@ -103,7 +103,7 @@
 
 <nav class="napkin-site-nav" aria-label="Site">
     <div class="napkin-site-nav__inner">
-        <a class="napkin-site-nav__brand" href="/napkin/" aria-label="napkin — home">
+        <a class="napkin-site-nav__brand" href="/" aria-label="napkin — home">
             <span class="napkin-site-nav__mark" aria-hidden="true">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M4 4 H20 V20 L4 20 L4 4 Z" />
@@ -113,8 +113,8 @@
             <span class="napkin-site-nav__wordmark">napkin</span>
         </a>
         <ul class="napkin-site-nav__links">
-            <li><a href="/napkin/">Home</a></li>
-            <li><a href="/napkin/documentation/napkin/">Docs</a></li>
+            <li><a href="/">Home</a></li>
+            <li><a href="/documentation/napkin/">Docs</a></li>
             <li><a href="https://github.com/WikipediaBrown/napkin/tree/main/Examples/LaunchNapkinApp">Example</a></li>
             <li><a href="https://github.com/WikipediaBrown/napkin">GitHub</a></li>
         </ul>

--- a/Tools/site/index.html
+++ b/Tools/site/index.html
@@ -11,7 +11,7 @@
     <meta property="og:title" content="napkin — a Swift framework for clean architecture">
     <meta property="og:description" content="Swift 6.2 framework. Trees of isolated, composable units. Modeled on RIBs.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://wikipediabrown.github.io/napkin/">
+    <meta property="og:url" content="https://getnapkin.to/">
 
     <link rel="icon" type="image/png" sizes="48x48" href="napkin-icon.png">
     <link rel="icon" type="image/png" sizes="96x96" href="napkin-icon@2x.png">
@@ -36,7 +36,7 @@
 
         <nav class="masthead__nav" aria-label="Primary">
             <ul>
-                <li><a href="/napkin/documentation/napkin/">Docs</a></li>
+                <li><a href="/documentation/napkin/">Docs</a></li>
                 <li><a href="https://github.com/WikipediaBrown/napkin/tree/main/Examples/LaunchNapkinApp">Example</a></li>
                 <li><a href="https://github.com/WikipediaBrown/napkin/blob/main/CHANGELOG.md">Changelog</a></li>
                 <li><a href="https://github.com/WikipediaBrown/napkin">GitHub</a></li>
@@ -70,7 +70,7 @@
         </p>
 
         <div class="cta-row">
-            <a class="btn btn--ink" href="/napkin/documentation/napkin/">
+            <a class="btn btn--ink" href="/documentation/napkin/">
                 <span>Read the docs</span>
                 <span class="btn__arrow" aria-hidden="true">→</span>
             </a>
@@ -240,7 +240,7 @@
 .<span class="tk-fn">package</span>(url: <span class="tk-str">"https://github.com/WikipediaBrown/napkin.git"</span>, from: <span class="tk-str">"__NAPKIN_VERSION__"</span>)</code></pre>
 
         <div class="cta-row">
-            <a class="btn btn--ink" href="/napkin/documentation/napkin/">
+            <a class="btn btn--ink" href="/documentation/napkin/">
                 <span>Read the docs</span>
                 <span class="btn__arrow" aria-hidden="true">→</span>
             </a>


### PR DESCRIPTION
## Summary

Pivots the public site from \`wikipediabrown.github.io/napkin/\` to \`getnapkin.to/\`.

With a custom domain on a project repo, GH Pages serves the artifact at the **domain root**, not at \`/<project-name>/\`, so the prior \`--hosting-base-path napkin\` and \`/napkin/...\` link prefixes break.

## Changes

- Drop \`--hosting-base-path napkin\` for the latest DocC build → root-relative links
- Versioned docs: \`--hosting-base-path "napkin/\${ref}"\` → \`"\${ref}"\`
- Homepage version dropdown: \`/napkin/\${ref}/...\` → \`/\${ref}/...\`
- Update nav/CTA links in \`Tools/site/index.html\` and \`Sources/napkin/napkin.docc/header.html\` to root paths
- Set \`og:url\` to \`https://getnapkin.to/\`
- New \"Write CNAME\" step → \`docs/CNAME\` contains \`getnapkin.to\` so the binding lives in source control

## DNS state (already in place per user)

- Apex \`getnapkin.to\`: A → 185.199.108–111.153 (GH Pages anycast)
- \`www.getnapkin.to\`: CNAME → \`wikipediabrown.github.io\`

GitHub will read \`docs/CNAME\` on the first deploy and provision a Let's Encrypt cert. \`https_enforced\` is already true.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge to develop → merge develop → main, Release auto-fires, Documentation builds, deploys
- [ ] \`https://getnapkin.to/\` serves the redesigned homepage with footer version stamp
- [ ] \`https://getnapkin.to/documentation/napkin/\` serves DocC
- [ ] \`https://getnapkin.to/2.0.14/documentation/napkin/\` serves the versioned DocC
- [ ] \`https://wikipediabrown.github.io/napkin/\` redirects to \`getnapkin.to\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)