### PR TITLE
Housekeeping + AGENTS.md + llms.txt + three new tutorials

### DIFF
--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -31,7 +31,10 @@ jobs:
     # macos-26 image as the rest of the build matrix so Xcode 26 / Swift 6.2
     # are available.
     runs-on: macos-26
-    timeout-minutes: 30
+    # `swift build` for the framework regularly takes 25+ minutes on the
+    # macos-26 runner; CodeQL's own analysis adds another 5–10. The 30-min
+    # default was hitting the wall before analysis could finish.
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -181,6 +181,28 @@ jobs:
           cp Tools/site/social-preview.png docs/social-preview.png
           cp Tools/site/rib-house-logged-out.png docs/rib-house-logged-out.png
           cp Tools/site/rib-house-logged-in.png docs/rib-house-logged-in.png
+          # llms.txt — emerging convention for LLM-readable site maps.
+          cp Tools/site/llms.txt docs/llms.txt
+          # llms-full.txt — same shape but with every article body inlined,
+          # generated from the .md files so it stays in sync with the catalog.
+          {
+            cat Tools/site/llms.txt
+            echo
+            echo "---"
+            echo
+            echo "# napkin (catalog root)"
+            echo
+            cat Sources/napkin/napkin.docc/napkin.md
+            for article in Sources/napkin/napkin.docc/Articles/*.md; do
+              name=$(basename "$article" .md)
+              echo
+              echo "---"
+              echo
+              echo "# Article: $name"
+              echo
+              cat "$article"
+            done
+          } > docs/llms-full.txt
 
           VERSION="${{ steps.versions.outputs.version }}"
           REFS="${{ steps.versions.outputs.refs }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,171 @@
+# AGENTS.md
+
+Instructions for AI coding agents working in the napkin repository. Follow these conventions and your changes will look like the rest of the codebase. Ignore them and a reviewer will ask you to redo the work.
+
+## What this project is
+
+napkin is a Swift 6.2 framework for clean-architecture iOS / macOS apps. It's a Swift Concurrency rewrite of Uber's [RIBs](https://github.com/uber/RIBs) — actors instead of base classes, `@MainActor` for routing/presentation, `Sendable` for everything that crosses an isolation boundary.
+
+Every feature is a **napkin**: a small unit composed of a fixed set of "rings" — Builder, Component, Interactor, Router, and (when there's a view) Presenter + ViewController. The pattern repeats across the framework; once you've written one napkin you've written all of them.
+
+## Build and test commands
+
+| Task | Command |
+|---|---|
+| Build the framework | `swift build` |
+| Run framework unit tests | `swift test` |
+| Run the example app | `open Examples/RibHouse/RibHouse.xcodeproj` (⌘R to launch) |
+| Run example UI + snapshot tests | `cd Examples/RibHouse && xcodebuild -project RibHouse.xcodeproj -scheme RibHouse -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" test` |
+| Regenerate the example's xcodeproj | `cd Examples/RibHouse && xcodegen` (only needed when you change `project.yml` or add files outside an existing folder) |
+| Build DocC locally | `swift package generate-documentation --target napkin` |
+
+CI runs the same commands on a `macos-26` runner with the highest non-beta Xcode 26.x (`grep -v -i beta` glob in workflows). Use the same simulator (`iPhone 17` / iOS 26) when reproducing failures.
+
+## Code conventions
+
+### One napkin per folder
+
+Each napkin's files live together in one folder under a `Sources/` directory (framework or example). Use the napkin's name as the folder name:
+
+```
+Examples/RibHouse/Sources/
+├── App/                       # AppDelegate, SceneDelegate, AppComponent, Info.plist
+├── Shared/                    # Cross-napkin types (services, models, palette)
+├── LaunchNapkin/              # Parent napkin
+├── LoggedOutNapkin/           # Child
+└── LoggedInNapkin/            # Child
+```
+
+A complete napkin folder typically contains 5–6 files named `<Napkin><Type>.swift`:
+
+```
+SomeNapkin/
+├── SomeNapkinBuilder.swift              # Dependency, Component, Builder
+├── SomeNapkinInteractor.swift           # Routing/Listener/Presentable protocols + Interactor actor
+├── SomeNapkinRouter.swift               # ViewControllable + Router
+├── SomeNapkinView.swift                 # SwiftUI view (skip for headless napkins)
+└── SomeNapkinHostingViewController.swift # UIHostingController / NSHostingController + PresentableListener
+```
+
+Headless napkins (no view of their own — e.g. orchestrators that only embed children) skip the View + HostingViewController and use a plain `UIViewController` instead.
+
+### Isolation: the four rings
+
+| Ring | Isolation | Stored as |
+|---|---|---|
+| Interactor | `final actor` | `final actor FooInteractor: Interactable, ...` |
+| Router | `@MainActor` | `@MainActor final class FooRouter: ViewableRouter<...>` |
+| Presenter / ViewController | `@MainActor` | `@MainActor final class FooViewController: UIHostingController<...>` |
+| Builder / Component | `Sendable` class | `final class FooBuilder: Builder<...>, ..., @unchecked Sendable` |
+
+The interactor is the **only** business-logic ring and it lives **off the main actor**. Don't make interactors `@MainActor` "for convenience" — that puts business logic on UIKit's executor and violates the architecture's whole reason for existing.
+
+### The two listener protocols
+
+Inside any napkin you'll see two listener protocols. They are *not* the same thing and live in different files:
+
+| Protocol | File | Direction | Purpose |
+|---|---|---|---|
+| `<Self>NapkinPresentableListener` | `<Self>NapkinHostingViewController.swift` | view → interactor | Forward taps and gestures from SwiftUI to the actor. Methods are named `didTapX()`, `didTypeX(_:)`, etc. |
+| `<Self>NapkinListener` | `<Self>NapkinInteractor.swift` | child interactor → parent interactor | Forward business intent up the tree. Methods are named `<self>NapkinDid<verb>()` — e.g. `loggedOutDidTapLogin()`, `counterDidFinish()`. |
+
+The parent interactor conforms to the child's `<Self>NapkinListener` and implements the methods. The router passes the parent interactor as `withListener:` when it builds the child.
+
+### View → interactor: `dispatch { }`, not `Task { }`
+
+SwiftUI button actions are `@MainActor` closures. The interactor is an actor. Bridging from one to the other goes through napkin's `dispatch` helper:
+
+```swift
+// CORRECT
+Button("Login") {
+    dispatch { [listener] in await listener?.didTapLogin() }
+}
+
+// WRONG (don't do this)
+Button("Login") {
+    Task { await listener?.didTapLogin() }
+}
+```
+
+`dispatch` is intentional about lifetime — it captures the listener weakly and drops the task if the view goes away mid-tap. Inline `Task { }` doesn't.
+
+### Cross-isolation patterns
+
+| Crossing | Pattern |
+|---|---|
+| Interactor → Presenter (`actor → @MainActor`) | `await presenter.update(...)` |
+| Interactor → Router (`actor → @MainActor`) | `await router?.routeToProfile()` |
+| View → Interactor (`@MainActor sync → actor`) | `dispatch { await listener?.didTapX() }` |
+| Interactor → Listener (parent interactor) | `await listener?.fooDidFinish()` |
+
+If you find yourself making something `@MainActor` to avoid `await`, you've usually broken the architecture. Add the `await` instead.
+
+### Don't subclass actors
+
+Swift actors can't be subclassed ([SE-0306](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0306-actors.md)). napkin uses **protocol composition** instead — `Interactable` is a protocol with a default extension that delegates lifecycle to a shared `InteractorLifecycle` helper. Each napkin's interactor declares:
+
+```swift
+final actor FooInteractor: PresentableInteractable, ...listenerConformances... {
+    nonisolated let lifecycle = InteractorLifecycle()
+    // ... your state and methods ...
+}
+```
+
+`final` is required. `nonisolated` on `lifecycle` is required. Don't try to write `class FooInteractor: PresentableInteractor<X>` — that base class no longer exists; the `PresentableInteractor.swift` file in the framework that mentions it is documentation, not code.
+
+## File naming + casing
+
+- Swift filenames: `<Napkin><Type>.swift` — e.g. `LoggedOutNapkinBuilder.swift`. Always include `Napkin` in the type name to keep search legible (`grep LoggedOut` returns too much; `grep LoggedOutNapkin` returns just the napkin).
+- Test filenames: same convention plus `Tests` — e.g. `LoggedOutNapkinViewSnapshotTests.swift`.
+- Folders: PascalCase, no `Napkin` suffix on the folder name itself — `LoggedOutNapkin/`, not `LoggedOutNapkinFolder/`.
+
+## Testing
+
+- **View-level**: snapshot tests using Point-Free's [swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing). Reference PNGs are committed under `Examples/RibHouse/SnapshotTests/__Snapshots__/`. First run records; subsequent runs verify.
+- **UI tests**: XCUITest in `Examples/RibHouse/UITests/`. Use accessibility identifiers from `Sources/Shared/AccessibilityIdentifiers.swift` — never query by text label.
+- **Framework unit tests**: in `Tests/napkinTests/`. Drive interactors by calling their methods directly; mock services with simple `final class Mock<protocol-name>: <protocol-name>` types.
+
+## Repository-level conventions
+
+- **Branches**: feature work on `develop`, releases on `main`. Branch off `develop`, PR back to `develop`. Merging develop → main triggers Release → Documentation.
+- **Commits**: imperative subject ("Add tab bar tutorial"), short body explaining the *why*. Co-authored trailer for AI assistance is fine.
+- **Don't push to `main` directly** — it's protected against force-push and deletion but allows regular pushes. The merge-from-develop-with-`--no-ff` flow is what triggers Release.
+- **Example app's `.xcodeproj` is tracked** so it opens without xcodegen. If you change `project.yml` or add a Swift file in a new folder, regenerate (`cd Examples/RibHouse && xcodegen`).
+
+## iCloud Drive trap
+
+If your clone is inside an iCloud Drive folder, you'll see `* 2.swift`, `* 3.swift`, ` 4.xcodeproj` artifacts appear. They're gitignored but SPM and xcodegen still see them on disk and may bake stale references into builds.
+
+**Before committing**, run:
+
+```bash
+find /path/to/napkin \( -name "* 2.*" -o -name "* 3.*" \) -not -path "*/.build/*" -print0 | xargs -0 rm -rf
+```
+
+Then re-run xcodegen if you regenerated the project recently.
+
+## What's in the source tree
+
+```
+napkin/
+├── Sources/napkin/                       # The framework
+│   ├── *.swift                           # Builder, Component, Router, ViewableRouter, LaunchRouter, Interactor, etc.
+│   ├── napkin.docc/                      # DocC catalog (articles, resources, theme)
+│   └── DI/                               # Component + dependency primitives
+├── Tests/napkinTests/                    # Framework tests (swift test)
+├── Snippets/                             # Code samples referenced by DocC articles
+├── Examples/
+│   ├── README.md
+│   └── RibHouse/                         # Runnable example app ("Napkin's Rib House")
+├── Tools/
+│   ├── site/                             # The marketing site (getnapkin.to)
+│   └── napkin/                           # Xcode templates for File > New File
+└── .github/workflows/                    # CI: Tests, Release, Documentation, CodeQL, etc.
+```
+
+## See also
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — human-facing contribution guide
+- [`README.md`](README.md) — what napkin is + a quick API tour
+- [DocC site](https://getnapkin.to/documentation/napkin/) — full architecture reference
+- [Tutorial: Building a Login Flow](https://getnapkin.to/documentation/napkin/tutorialbuildingaloginflow) — a guided walkthrough of the example app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,113 @@ All notable changes to napkin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `AGENTS.md` at the repo root — conventions for AI coding agents working
+  in the codebase (napkin folder layout, isolation patterns, listener
+  protocols, `dispatch { }` vs `Task { }`, file naming, iCloud-Drive
+  artifact warning).
+- `getnapkin.to/llms.txt` and `/llms-full.txt` — emerging conventions for
+  LLM-readable site maps. The full variant is generated at deploy time
+  from the DocC `.md` files so it stays in sync with the catalog.
+- `Sources/napkin/napkin.docc/Articles/TutorialBuildingALoginFlow.md` —
+  guided walkthrough of the runnable example app (Napkin's Rib House)
+  through the napkin pattern, end to end. Uses `@TabNavigator`,
+  `@Row`/`@Column`, asides, and `@Links(visualStyle: detailedGrid)`.
+- "Step 7: Snapshot testing the views" section in the tutorial — covers
+  declaring the package, target wiring, record-then-verify workflow, and
+  the two ways to opt into re-record mode.
+- `Examples/RibHouse/SnapshotTests/` — Point-Free
+  [swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing)
+  target. Reference PNGs under `__Snapshots__/` pin each view's
+  appearance. The same PNGs are committed to
+  `Sources/napkin/napkin.docc/Resources/` and `Tools/site/` so the
+  tutorial and homepage display the exact images CI compares against.
+- New "§ 04 · See it in motion" section on the homepage — auto-cycling
+  4-step tutorial: iPhone-framed snapshot fades between LoggedOut and
+  LoggedIn while code blocks stagger their lines in like an editor
+  typing them out. Pure CSS animation + ~30 lines of vanilla JS;
+  `prefers-reduced-motion` stacks the four steps statically.
+
+### Changed
+
+- `Examples/LaunchNapkinApp` renamed to `Examples/RibHouse` ("Napkin's
+  Rib House") with a barbecue-themed `AuthService` mock. Display name
+  is `Napkin's Rib House`; bundle ID is `com.napkin.example.RibHouse`.
+- The example app's source tree is now organized one-napkin-per-folder
+  (`App/`, `Shared/`, `LaunchNapkin/`, `LoggedOutNapkin/`,
+  `LoggedInNapkin/`). UI test file renamed to `RibHouseUITests.swift`.
+- The example app's `.xcodeproj` is now **tracked in source control** —
+  the project opens via `open Examples/RibHouse/RibHouse.xcodeproj`
+  without an XcodeGen step. `.gitignore` un-ignores the project
+  explicitly while still ignoring user state.
+- Example app architecture pivoted from the prior Counter + Quote demo
+  to a login/logout flow that exercises service injection: a headless
+  `LaunchNapkin` holds an `AuthService` (declared in the dependency
+  protocol) and swaps a `LoggedOutNapkin` (single Login button) for
+  a `LoggedInNapkin` (user name + barbecue food list) on tap. The
+  `User` object flows through the full
+  interactor → router → builder → child router chain.
+- LoggedOut and LoggedIn views restyled with editorial vocabulary
+  matching the marketing site — kicker (`§ 00 · WELCOME`),
+  serif-italic headlines, hairline rules, spec-list pattern for the
+  foods, ink + ghost buttons. Palette tokens in `Shared/Palette.swift`
+  are derived from the site's OKLCH design tokens.
+- `Sources/napkin/napkin.docc/theme-settings.json` link + intro-accent
+  colors flipped from blue to moss-green so the docs and homepage
+  read as the same design system.
+- `social-preview.svg` now has `role="img"` + `<title>` + `<desc>` +
+  `aria-labelledby` so screen readers reading the inline SVG get the
+  same description as sighted users.
+- `Gemfile.lock`: `activesupport` 8.1.2 → 8.1.3 (clears 3 moderate
+  Dependabot alerts on Rails CVEs in `number_to_delimited`,
+  `SafeBuffer#%`, and number helpers — fastlane transitive dep).
+- `.github/workflows/Documentation.yml`: `actions/checkout` uses
+  shallow + tags + explicit `ref: main`, fixing the APFS case-collision
+  that masked deploys when `ci/...` namespaced branches existed
+  alongside the stale `CI` branch.
+- `.github/workflows/Release.yml`: narrows `remote.origin.fetch` to
+  `main` before fastlane's `git_pull(only_tags: true)` to avoid the
+  same case-collision.
+- `.github/workflows/CodeQL.yml`: switched from `autobuild` to manual
+  `swift build` after autobuild repeatedly tripped on a stale SPM
+  cache reference to `swift-docc-plugin`.
+- `CONTRIBUTING.md` paths updated for the RibHouse rename and the
+  tracked-xcodeproj workflow (xcodegen is now optional).
+
+### Removed
+
+- `Examples/LaunchNapkinApp/` (renamed; see Changed).
+- The "Counter" and "Quote" child napkins from the example app
+  (replaced by LoggedOut and LoggedIn).
+- Stale local-only `Sources/napkin/PresentableInteractor.swift` orphan
+  — a pre-rearchitecture class-based interactor that referenced types
+  removed in 2.0.0. Was untracked but present in iCloud-synced clones.
+- The original `CI`, `Adding-Templates`, `Fastlane`, `TemplateFix`, and
+  `swift-concurrency-rearchitecture` branches on origin (stale, all
+  predate the v2 rearchitecture).
+
+### Infrastructure
+
+- Migrated public site to a custom domain: **https://getnapkin.to/**.
+  Apex A records target GitHub Pages' anycast IPs; `www.getnapkin.to`
+  CNAMEs to `wikipediabrown.github.io`; HTTPS enforced; cert covers
+  both apex and `www`. `wikipediabrown.github.io/napkin/` 301s to the
+  custom domain.
+- Enabled GitHub Sponsors button via `.github/FUNDING.yml`.
+- Enabled repository security analysis: secret scanning, push
+  protection, Dependabot security updates, and private vulnerability
+  reporting.
+- Added branch protection on `main` and `develop` (block force-push
+  and deletions; regular pushes still allowed).
+- Repo About panel: homepage URL now `https://getnapkin.to/`;
+  obsolete `combine` topic dropped; `swift-6` and
+  `structured-concurrency` topics added.
+- New CI workflow `.github/workflows/CodeQL.yml` runs weekly + on
+  push/PR for Swift static analysis on the `macos-26` runner.
+
 ## [2.0.8]
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.8)
     abbrev (0.1.2)
-    activesupport (8.1.2)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -223,7 +223,8 @@ GEM
     logger (1.7.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
-    minitest (6.0.1)
+    minitest (6.0.6)
+      drb (~> 2.0)
       prism (~> 1.5)
     multi_json (1.21.1)
     multipart-post (2.4.1)

--- a/Sources/napkin/napkin.docc/Articles/AddingANetworkedService.md
+++ b/Sources/napkin/napkin.docc/Articles/AddingANetworkedService.md
@@ -1,0 +1,196 @@
+# Adding a Networked Service
+
+Replace the example app's mock `BarbecueAuthService` with a real `URLSession`-backed implementation. The point: the napkin tree above the service doesn't change.
+
+@Metadata {
+    @PageImage(purpose: icon, source: "napkin-icon", alt: "napkin logo")
+    @PageColor(green)
+    @TitleHeading("Tutorial")
+}
+
+## Overview
+
+The example app's `LaunchNapkin` doesn't depend on a service implementation — it depends on a *protocol*:
+
+```swift
+protocol LaunchNapkinDependency: Dependency {
+    var authService: AuthService { get }
+}
+```
+
+That decoupling is what makes the auth flow swappable. The shipped example wires in a `BarbecueAuthService` mock that returns Smokey Joe synchronously. A real app would swap it for a `URLSessionAuthService` that talks to a server. Nothing else in the napkin tree changes — same dependency, same builder, same interactor, same listener calls.
+
+This article walks the swap, line by line.
+
+## Step 1: The contract
+
+The interactor only knows the protocol. As long as your concrete impl matches the shape, it slots in:
+
+```swift
+protocol AuthService: Sendable {
+    func login() async throws -> User
+    func logout() async throws
+}
+```
+
+Three things to internalize:
+
+@Row {
+    @Column {
+        **`Sendable`** — the service is held by an `actor` (`LaunchNapkinInteractor`) and called from anywhere. The conformance is the compiler's guarantee that crossing the actor boundary is safe.
+    }
+    @Column {
+        **`async`** — `URLSession` is naturally async. The protocol already accommodates a real implementation; the mock just doesn't *need* to suspend.
+    }
+}
+
+`throws` lets the implementation surface errors without inventing a result type. The interactor's `try await authService.login()` already handles both throw and return cases.
+
+> Tip: Keep `AuthService` in `Sources/Shared/` (or your equivalent). It's not the LaunchNapkin's contract — it's the contract every napkin in the tree could potentially consume. (LoggedInNapkin already declares it in its `Dependency` protocol, even though it doesn't currently call it.)
+
+## Step 2: A concrete `URLSessionAuthService`
+
+Replace the mock with a class that performs real I/O. The implementation lives next to the protocol; the rest of the tree stays untouched.
+
+```swift
+import Foundation
+
+/// Production AuthService — talks to the smokehouse's REST API.
+///
+/// Sendable because every property is `let` and `URLSession` is `Sendable`
+/// (it's a reference type whose underlying queue is internally synchronized).
+final class URLSessionAuthService: AuthService {
+    private let session: URLSession
+    private let baseURL: URL
+    private let decoder = JSONDecoder()
+
+    init(session: URLSession = .shared, baseURL: URL) {
+        self.session = session
+        self.baseURL = baseURL
+    }
+
+    func login() async throws -> User {
+        var request = URLRequest(url: baseURL.appendingPathComponent("login"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+        try Self.assertSuccess(response)
+
+        let payload = try decoder.decode(UserPayload.self, from: data)
+        return User(name: payload.name, barbecueFoods: payload.foods)
+    }
+
+    func logout() async throws {
+        var request = URLRequest(url: baseURL.appendingPathComponent("logout"))
+        request.httpMethod = "POST"
+        let (_, response) = try await session.data(for: request)
+        try Self.assertSuccess(response)
+    }
+
+    private static func assertSuccess(_ response: URLResponse) throws {
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw AuthError.badResponse((response as? HTTPURLResponse)?.statusCode ?? -1)
+        }
+    }
+
+    private struct UserPayload: Decodable {
+        let name: String
+        let foods: [String]
+    }
+}
+
+enum AuthError: Error, Sendable {
+    case badResponse(Int)
+}
+```
+
+A few things worth a closer look:
+
+- **`final class` + `Sendable`.** Reference type because `URLSession` is a reference type and we want one instance shared across the napkin tree. `final` + immutable stored properties + `Sendable`-conforming property types = the compiler infers `Sendable` automatically.
+- **Decoder is a `let` instance variable**, not a fresh one per call. JSONDecoder is reasonably expensive to construct and threadsafe to read from.
+- **`URLSession.data(for:)` is the modern async API.** It returns `(Data, URLResponse)` and propagates cancellation. If the calling task is cancelled (e.g. user navigates away mid-request), the request is cancelled too.
+- **`AuthError` is `Sendable`** so it can cross actor boundaries when thrown.
+
+## Step 3: Wire it in at the dependency root
+
+The only line that changes is in `SceneDelegate.swift`'s `AppComponent`:
+
+```swift
+final class AppComponent: Component<EmptyDependency>, LaunchNapkinDependency, @unchecked Sendable {
+    let authService: AuthService
+
+    init() {
+        let api = URL(string: "https://api.smokehouse.example/v1")!
+        self.authService = URLSessionAuthService(baseURL: api)
+        super.init(dependency: EmptyComponent())
+    }
+}
+```
+
+That's it. No interactor, router, builder, or view file changes. The mock is gone; the network service takes its place. Every napkin in the tree still reads `dependency.authService` and gets *the same protocol*.
+
+> Note: A production app would inject the base URL from configuration (build setting, `Info.plist`, environment variable, feature flag service). Hardcoding it in `AppComponent.init` is fine for the example.
+
+## Step 4: Handling cancellation
+
+Long network requests should cancel when their work is no longer needed. The napkin pattern already gives you this for free:
+
+```swift
+final actor LaunchNapkinInteractor: ... {
+    func loggedOutDidTapLogin() async {
+        do {
+            let user = try await authService.login()
+            await router?.attachLoggedIn(user: user)
+        } catch is CancellationError {
+            // The user navigated away before the request completed —
+            // nothing to do. The actor has already been deactivated.
+        } catch {
+            // Real failure: log, surface, or stay on logged-out.
+        }
+    }
+}
+```
+
+A `CancellationError` from `URLSession.data(for:)` means the parent task was cancelled — usually because the napkin is being torn down. Bail silently. Any other error is a real failure (network down, bad credentials, server 500).
+
+> Important: `URLSessionAuthService` doesn't need its own cancellation plumbing. Swift's `async`/`await` propagates cancellation through the task hierarchy automatically. If the LaunchNapkin's interactor task is cancelled, the in-flight `URLSession` request is cancelled too.
+
+## Step 5: Testing the swap
+
+The interactor tests written against the *mock* in <doc:TestingANapkin> don't need to change when you swap implementations. They test that the interactor calls the protocol correctly — not what the protocol does behind the scenes.
+
+For the `URLSessionAuthService` itself, a separate test exercises just the networking concern, often against a mocked `URLSession` or `URLProtocol` subclass. That's a "service test" — out of scope here, but the typical shape:
+
+```swift
+final class URLSessionAuthServiceTests: XCTestCase {
+    func testLogin_returnsDecodedUser() async throws {
+        // Spin up a URLProtocol that intercepts requests and returns canned JSON.
+        // Configure a URLSession with that protocol class in its configuration.
+        // Assert that calling login() returns a User with the expected fields.
+    }
+}
+```
+
+The point: separating the protocol (LaunchNapkin's concern) from the impl (network concern) means you write *two small tests* instead of one tangled integration test.
+
+## What didn't change
+
+If you've come from a "view model talks to a singleton" style codebase, the most interesting thing about this swap is what *didn't* need to change:
+
+- **The LaunchInteractor**. Same method body, same `try await authService.login()`.
+- **The LaunchRouter**. Same `attachLoggedIn(user:)`.
+- **Every child napkin**. The LoggedOut and LoggedIn napkins never knew the service existed.
+- **The tests**. Mock-based interactor tests assert on the contract, not the implementation.
+
+That's the dependency-injection-via-protocol pattern doing exactly what it's supposed to do. Swap the leaf, leave the tree alone.
+
+## Topics
+
+### Related
+
+@Links(visualStyle: detailedGrid) {
+    - <doc:TutorialBuildingALoginFlow>
+    - <doc:TestingANapkin>
+    - <doc:CrossIsolationPatterns>
+}

--- a/Sources/napkin/napkin.docc/Articles/TabBarNapkin.md
+++ b/Sources/napkin/napkin.docc/Articles/TabBarNapkin.md
@@ -1,0 +1,260 @@
+# Tab Bar Napkin
+
+A different routing pattern than the swap demo. A parent napkin attaches multiple children *concurrently*, hosted side-by-side in a `UITabBarController`. Only one is visible at a time, but all stay active.
+
+@Metadata {
+    @PageImage(purpose: icon, source: "napkin-icon", alt: "napkin logo")
+    @PageColor(green)
+    @TitleHeading("Tutorial")
+}
+
+## Overview
+
+Most napkin examples show **swap routing**: one child active at a time, detach-then-attach when state changes (e.g. `LoggedOutNapkin` ↔ `LoggedInNapkin` in <doc:TutorialBuildingALoginFlow>). Tab bars need a different pattern: **concurrent routing**, where multiple children are attached at the same time and the parent controls which is *visible*.
+
+```
+TabBarNapkin (parent, owns UITabBarController)
+├── HomeNapkin       ← all three attached concurrently
+├── BrowseNapkin     ←
+└── ProfileNapkin    ← only one visible at a time
+```
+
+The interactor never detaches a child when the user switches tabs — they all stay active, with their own state, ready to be brought to the front instantly. Only the *view controller* (the `UITabBarController`) cares which one is on screen.
+
+> Note: Compare this to a `UINavigationController` push, which is a third pattern: children are attached *one at a time on top of each other*, and the parent's stack is the source of truth for navigation. napkin's routing primitives support all three; the pattern lives in the router, not in the framework.
+
+## Step 1: The shape
+
+A `TabBarNapkin` has the same six-file shape as any other parent napkin, but with three differences:
+
+@Row {
+    @Column {
+        **The router holds N child routers**, one per tab. None of them are optional — they're all populated at build time.
+    }
+    @Column {
+        **The view controller is a `UITabBarController` subclass** that exposes a method for the router to install the children's view controllers.
+    }
+}
+
+Let's build the pieces.
+
+### Dependency + Component + Builder
+
+Standard shape. The dependency declares whatever services the tab bar's interactor and any children need:
+
+```swift
+protocol TabBarNapkinDependency: Dependency {
+    var authService: AuthService { get }
+    // ...any other shared services
+}
+
+final class TabBarNapkinComponent: Component<TabBarNapkinDependency>, @unchecked Sendable {
+    var authService: AuthService { dependency.authService }
+}
+
+// Conform to each child's dependency protocol so we can pass `component` as `dependency:`.
+extension TabBarNapkinComponent:
+    HomeNapkinDependency, BrowseNapkinDependency, ProfileNapkinDependency {}
+```
+
+The builder constructs every child up-front:
+
+```swift
+final class TabBarNapkinBuilder: Builder<TabBarNapkinDependency>, TabBarNapkinBuildable, @unchecked Sendable {
+    @MainActor
+    func build(withListener listener: TabBarNapkinListener) async -> TabBarNapkinRouting {
+        let component = TabBarNapkinComponent(dependency: dependency)
+        let homeBuilder = HomeNapkinBuilder(dependency: component)
+        let browseBuilder = BrowseNapkinBuilder(dependency: component)
+        let profileBuilder = ProfileNapkinBuilder(dependency: component)
+
+        let viewController = TabBarNapkinViewController()
+        let interactor = TabBarNapkinInteractor()
+        await interactor.set(listener: listener)
+        let router = TabBarNapkinRouter(
+            interactor: interactor,
+            viewController: viewController,
+            homeBuilder: homeBuilder,
+            browseBuilder: browseBuilder,
+            profileBuilder: profileBuilder
+        )
+        await interactor.set(router: router)
+        return router
+    }
+}
+```
+
+## Step 2: The router
+
+This is where the pattern diverges most from the swap demo. The router builds and attaches *all* children when it loads, then never detaches them until the napkin itself is torn down.
+
+```swift
+@MainActor
+protocol TabBarNapkinViewControllable: ViewControllable {
+    func installTabs(_ children: [ViewControllable])
+}
+
+@MainActor
+final class TabBarNapkinRouter:
+    ViewableRouter<TabBarNapkinInteractor, TabBarNapkinViewControllable>,
+    TabBarNapkinRouting
+{
+    private let homeBuilder: HomeNapkinBuildable
+    private let browseBuilder: BrowseNapkinBuildable
+    private let profileBuilder: ProfileNapkinBuildable
+
+    private var homeRouter: HomeNapkinRouting?
+    private var browseRouter: BrowseNapkinRouting?
+    private var profileRouter: ProfileNapkinRouting?
+
+    init(
+        interactor: TabBarNapkinInteractor,
+        viewController: TabBarNapkinViewControllable,
+        homeBuilder: HomeNapkinBuildable,
+        browseBuilder: BrowseNapkinBuildable,
+        profileBuilder: ProfileNapkinBuildable
+    ) {
+        self.homeBuilder = homeBuilder
+        self.browseBuilder = browseBuilder
+        self.profileBuilder = profileBuilder
+        super.init(interactor: interactor, viewController: viewController)
+    }
+
+    // Override the framework's load() to build + attach every child once.
+    override func didLoad() async {
+        await super.didLoad()
+        let home = await homeBuilder.build(withListener: interactor)
+        let browse = await browseBuilder.build(withListener: interactor)
+        let profile = await profileBuilder.build(withListener: interactor)
+        self.homeRouter = home
+        self.browseRouter = browse
+        self.profileRouter = profile
+        await attachChild(home)
+        await attachChild(browse)
+        await attachChild(profile)
+        viewController.installTabs([
+            home.viewControllable,
+            browse.viewControllable,
+            profile.viewControllable,
+        ])
+    }
+}
+```
+
+> Important: All three children are `attachChild`-ed which means all three have their `didBecomeActive` fired. That's the *point* of the tab bar pattern — each child stays live (its state persists) when the user is on a different tab.
+
+## Step 3: The view controller
+
+A thin wrapper around `UITabBarController`:
+
+```swift
+#if canImport(UIKit)
+import UIKit
+
+@MainActor
+final class TabBarNapkinViewController: UITabBarController, TabBarNapkinViewControllable {
+
+    func installTabs(_ children: [ViewControllable]) {
+        let vcs = children.map { $0.uiviewController }
+        // Optional: configure tabBarItem on each (icon, title) here or in the
+        // children's own ViewControllers via override init.
+        setViewControllers(vcs, animated: false)
+    }
+}
+#elseif canImport(AppKit)
+// AppKit has no direct UITabBarController equivalent; for macOS use NSTabViewController.
+#endif
+```
+
+That's the entire visible UI of the parent napkin — `UITabBarController` handles tab selection, the tab bar itself, the per-child navigation chrome, and the swap-on-tap. The parent's `Interactor` doesn't need to know which tab is currently visible unless its business logic depends on it.
+
+## Step 4: When the interactor *does* care about selection
+
+For pure tab-switching, the interactor is a no-op. But sometimes you want analytics, deep-link routing, or business logic tied to the active tab. The pattern:
+
+1. The view controller becomes the tab bar's `delegate` and forwards selections to a presenter listener.
+2. The interactor conforms to that listener and updates state.
+
+```swift
+@MainActor
+final class TabBarNapkinViewController: UITabBarController, ..., UITabBarControllerDelegate {
+    weak var listener: TabBarNapkinPresentableListener?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        delegate = self
+    }
+
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        let index = tabBarController.selectedIndex
+        dispatch { [listener] in await listener?.didSelectTab(at: index) }
+    }
+}
+```
+
+```swift
+protocol TabBarNapkinPresentableListener: AnyObject, Sendable {
+    func didSelectTab(at index: Int) async
+}
+
+final actor TabBarNapkinInteractor: PresentableInteractable, ..., TabBarNapkinPresentableListener {
+    private var selectedIndex: Int = 0
+
+    func didSelectTab(at index: Int) async {
+        selectedIndex = index
+        // Fire analytics, update routing state, etc.
+    }
+}
+```
+
+> Tip: The selected tab is *view state*. Don't store it in the interactor unless your *business logic* needs it. If you only need it for analytics, fire the event from the view controller's delegate method directly and skip the round-trip through the actor.
+
+## Step 5: Wiring children that need to talk back
+
+Each child napkin has its own `<Self>NapkinListener` protocol that the parent's interactor implements. Just like the swap demo:
+
+```swift
+protocol HomeNapkinListener: AnyObject, Sendable {
+    func homeDidRequestProfile() async
+}
+
+final actor TabBarNapkinInteractor: ..., HomeNapkinListener, BrowseNapkinListener, ProfileNapkinListener {
+    // The Home tab can ask the tab bar to switch to the Profile tab.
+    func homeDidRequestProfile() async {
+        await router?.selectTab(.profile)  // expose this method on TabBarNapkinRouting
+    }
+}
+```
+
+This is how children **influence** parent state without **owning** it. Same listener pattern, same actor isolation, just more siblings.
+
+## Comparison: swap vs tab bar
+
+@Row {
+    @Column {
+        **Swap routing** (LoggedOut ↔ LoggedIn)
+        - One child attached at a time
+        - Detach before attach
+        - Child state dies on swap
+        - Use when only one mode is valid (auth gate)
+    }
+    @Column {
+        **Tab bar routing** (Home + Browse + Profile)
+        - All children attached concurrently
+        - No detach during tab switching
+        - Each tab's state persists
+        - Use when the user moves between equally-valid views
+    }
+}
+
+The framework supports both with the same primitives — `attachChild` / `detachChild` from ``Router``, and your napkin's choice of when to call them. The Router is the only ring that has to know about the difference.
+
+## Topics
+
+### Related
+
+@Links(visualStyle: detailedGrid) {
+    - <doc:TutorialBuildingALoginFlow>
+    - <doc:HeadlessNapkins>
+    - <doc:TestingANapkin>
+}

--- a/Sources/napkin/napkin.docc/Articles/TestingANapkin.md
+++ b/Sources/napkin/napkin.docc/Articles/TestingANapkin.md
@@ -1,0 +1,261 @@
+# Testing a Napkin
+
+How to unit-test an `actor`-based interactor without booting a simulator: mock the presenter, mock the service, drive lifecycle directly, assert on recorded calls.
+
+@Metadata {
+    @PageImage(purpose: icon, source: "napkin-icon", alt: "napkin logo")
+    @PageColor(green)
+    @TitleHeading("Tutorial")
+}
+
+## Overview
+
+`Examples/RibHouse/SnapshotTests/` pins the SwiftUI *views*. This article covers the more interesting half: testing the **business logic** in your interactor actors. The two run in different test targets and exist for different reasons:
+
+@Row {
+    @Column {
+        **Snapshot tests** assert that the *render* matches a recorded image.
+        - Run on iOS simulator (`bundle.unit-test` with a UIKit host)
+        - Verify visual regressions
+        - Test target: `RibHouseSnapshotTests`
+    }
+    @Column {
+        **Interactor tests** assert that *business logic* fires the right side effects.
+        - Run on plain Swift (no simulator)
+        - Verify routing, service calls, listener notifications
+        - Test target: `napkinTests` or `RibHouseInteractorTests`
+    }
+}
+
+This article focuses on the second. We'll write tests for `LoggedOutNapkinInteractor` (a leaf, just forwards a tap) and `LaunchNapkinInteractor` (the orchestrator that calls the service and routes).
+
+## Step 1: The mocking pattern
+
+napkin interactors collaborate with three things: a **presenter**, a **router**, and (often) a **listener**. All three are protocols, which is what makes the interactor trivially testable. Replace each protocol with a `final class` that records calls.
+
+```swift
+import XCTest
+@testable import RibHouse
+
+/// Records every method the interactor calls on it, plus any state
+/// the interactor sets through the property.
+@MainActor
+final class MockLoggedOutNapkinPresentable: LoggedOutNapkinPresentable {
+    weak var listener: LoggedOutNapkinPresentableListener?
+    var updateCount = 0
+}
+```
+
+> Note: The presenter is `@MainActor`. The mock that conforms to it must be too. Interactors are `actor`s — they'll `await` into the `@MainActor` mock just like they would into the real `UIHostingController`. No special test-only ceremony required.
+
+For the listener (the side the interactor talks *up* to), the mock records intent calls:
+
+```swift
+final class MockLaunchToLoggedOutListener: LoggedOutNapkinListener, @unchecked Sendable {
+    // The interactor under test calls these on us. We just count them.
+    var loggedOutDidTapLoginCalls = 0
+    func loggedOutDidTapLogin() async {
+        loggedOutDidTapLoginCalls += 1
+    }
+}
+```
+
+`@unchecked Sendable` because the mock has mutable state (the counter) but is only ever touched from the actor that owns it during the test — the compiler can't prove that, so we mark it manually. In a multi-threaded test you'd want a proper synchronization primitive.
+
+## Step 2: A leaf interactor test
+
+Test `LoggedOutNapkinInteractor.didTapLogin()`: when the view (or test) calls it, the interactor should turn around and call `listener?.loggedOutDidTapLogin()` exactly once.
+
+```swift
+@MainActor
+final class LoggedOutNapkinInteractorTests: XCTestCase {
+
+    func testDidTapLogin_forwardsToListener() async {
+        // Arrange
+        let presenter = MockLoggedOutNapkinPresentable()
+        let listener = MockLaunchToLoggedOutListener()
+        let sut = LoggedOutNapkinInteractor(presenter: presenter)
+        await sut.set(listener: listener)
+
+        // Act
+        await sut.didTapLogin()
+
+        // Assert
+        XCTAssertEqual(listener.loggedOutDidTapLoginCalls, 1)
+    }
+}
+```
+
+Three things to notice:
+
+1. **The actor's methods are `async`.** We `await` them from the `@MainActor` test method. Swift Testing or XCTest both support this — no need for `XCTestExpectation`.
+2. **No view in sight.** The view (and the SwiftUI tree it lives in) is irrelevant to whether the interactor forwards the tap. That's exactly the point of having an actor with a Presentable protocol — you can test business logic without rendering anything.
+3. **No router.** The leaf interactor's job is to forward the intent; routing is the parent's responsibility. We don't even need to mock the router for this test.
+
+> Tip: Name your tests `test<Method>_<expectedBehavior>`. The first half tells the reader *what* you're calling; the second half tells them *what should happen*. The whole name should read like a sentence.
+
+## Step 3: An orchestrator test (the router pattern)
+
+`LaunchNapkinInteractor.loggedOutDidTapLogin()` does more: it calls `authService.login()`, then asks the router to attach the LoggedIn napkin with the returned user. Two collaborators to mock.
+
+### Mock the service
+
+```swift
+final class MockAuthService: AuthService, @unchecked Sendable {
+    var loginResult: Result<User, Error> = .success(.init(name: "Test User", barbecueFoods: []))
+    var loginCalls = 0
+    var logoutCalls = 0
+
+    func login() async throws -> User {
+        loginCalls += 1
+        return try loginResult.get()
+    }
+    func logout() async throws {
+        logoutCalls += 1
+    }
+}
+```
+
+A `Result`-based stub lets you switch the test between the happy path (`.success`) and a failure path (`.failure(SomeError.network)`) without rewriting the mock.
+
+### Mock the router
+
+The router is `@MainActor` and conforms to `LaunchNapkinRouting`. Same pattern:
+
+```swift
+@MainActor
+final class MockLaunchNapkinRouting: LaunchNapkinRouting {
+    var attachLoggedOutCalls = 0
+    var attachLoggedInCalls = [(user: User, count: Int)]()
+
+    func attachLoggedOut() async { attachLoggedOutCalls += 1 }
+    func attachLoggedIn(user: User) async {
+        attachLoggedInCalls.append((user, attachLoggedInCalls.count + 1))
+    }
+
+    // LaunchRouting requirements (children, attachChild/detachChild/load) — stub them out
+    // or inherit a no-op base if you have one.
+    var children: [Routing] { [] }
+    func load() async {}
+    nonisolated var interactable: Interactable {
+        fatalError("not exercised in this test")
+    }
+}
+```
+
+> Important: Conforming to `LaunchRouting` and its parents (`Routing`) means stubbing a few inherited members. For most interactor tests, this boilerplate is a one-time cost — extract it into a `BaseMockRouter` if you find yourself writing it in more than two test files.
+
+### The test
+
+```swift
+@MainActor
+final class LaunchNapkinInteractorTests: XCTestCase {
+
+    func testLoggedOutDidTapLogin_callsServiceAndAttachesLoggedIn() async throws {
+        // Arrange
+        let auth = MockAuthService()
+        let user = User(name: "Smokey Joe", barbecueFoods: ["Brisket", "Ribs"])
+        auth.loginResult = .success(user)
+        let router = MockLaunchNapkinRouting()
+        let sut = LaunchNapkinInteractor(authService: auth)
+        await sut.set(router: router)
+
+        // Act
+        await sut.loggedOutDidTapLogin()
+
+        // Assert
+        XCTAssertEqual(auth.loginCalls, 1)
+        XCTAssertEqual(router.attachLoggedInCalls.count, 1)
+        XCTAssertEqual(router.attachLoggedInCalls.first?.user, user)
+        XCTAssertEqual(router.attachLoggedOutCalls, 0)
+    }
+
+    func testLoggedOutDidTapLogin_onLoginFailure_doesNotAttachLoggedIn() async {
+        // Arrange
+        let auth = MockAuthService()
+        auth.loginResult = .failure(MockError.unauthorized)
+        let router = MockLaunchNapkinRouting()
+        let sut = LaunchNapkinInteractor(authService: auth)
+        await sut.set(router: router)
+
+        // Act
+        await sut.loggedOutDidTapLogin()
+
+        // Assert
+        XCTAssertEqual(auth.loginCalls, 1)
+        XCTAssertEqual(router.attachLoggedInCalls.count, 0)
+        // We're still on the logged-out screen because the router was never asked to swap.
+    }
+
+    private enum MockError: Error { case unauthorized }
+}
+```
+
+Two scenarios from one mock. The interactor's logic — "on login error, stay on the logged-out screen" — is now pinned in the test suite. If a future change makes the interactor *also* attach an error-state napkin, that test would need to assert against a new branch. Failure modes become first-class.
+
+## Step 4: Testing lifecycle
+
+`didBecomeActive` is the napkin's `viewDidLoad`. Test it like any other method — it's just an `async` function on the actor.
+
+```swift
+@MainActor
+final class LaunchNapkinInteractor_LifecycleTests: XCTestCase {
+
+    func testDidBecomeActive_attachesLoggedOut() async {
+        let auth = MockAuthService()
+        let router = MockLaunchNapkinRouting()
+        let sut = LaunchNapkinInteractor(authService: auth)
+        await sut.set(router: router)
+
+        await sut.didBecomeActive()
+
+        XCTAssertEqual(router.attachLoggedOutCalls, 1)
+    }
+}
+```
+
+The framework's `Interactable` extension also exposes `activate()` and `deactivate()` if you want to drive the actor through its full lifecycle (which fires `didBecomeActive` / `willResignActive` as side effects). For most tests, calling the lifecycle method directly is more legible.
+
+> Experiment: Try writing a test that activates *twice* in a row and asserts `attachLoggedOutCalls` is still 1 (the framework guards against double-activate). It's a one-line addition to the existing test and proves the invariant is real.
+
+## Step 5: Wiring up a test target
+
+In a SwiftPM library, tests go in `Tests/napkinTests/` and run via `swift test`. For the example app, add a `bundle.unit-test` target to `Examples/RibHouse/project.yml` similar to the snapshot target:
+
+```yaml
+RibHouseInteractorTests:
+  type: bundle.unit-test
+  platform: iOS
+  sources:
+    - path: InteractorTests
+  dependencies:
+    - target: RibHouse
+  settings:
+    base:
+      IPHONEOS_DEPLOYMENT_TARGET: "26.0"
+      SWIFT_VERSION: "6.2"
+      TEST_HOST: "$(BUILT_PRODUCTS_DIR)/RibHouse.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RibHouse"
+      BUNDLE_LOADER: "$(TEST_HOST)"
+```
+
+Then regenerate (`xcodegen`) and the tests show up in Xcode's Test navigator and run via `xcodebuild test`.
+
+## Common patterns
+
+**Avoid the temptation to make interactors `@MainActor` "for testability."** It hurts the architecture and doesn't help — `actor` methods are already trivially `async`-testable. Going `@MainActor` would force every test to be `@MainActor` (often awkward when you'd rather not block the main scheduler).
+
+**Don't mock `final actor` types.** You can't subclass them anyway. Inject collaborators by protocol (which is the napkin pattern by default) and mock those.
+
+**Don't assert on the order of `await`s.** Two `await`s in an actor method are sequential by definition; the actor's serial executor enforces it. Asserting "first the service was called, *then* the router was attached" is testing the language, not your code. Assert on observable state ("the router has exactly one attach call").
+
+**Test the interactor's contract, not its internals.** If you find yourself needing to peek at a private property, the test is probably checking the wrong thing. The contract is *"calling X causes Y to happen"* — that's all the test should verify.
+
+## Topics
+
+### Related
+
+@Links(visualStyle: detailedGrid) {
+    - <doc:CrossIsolationPatterns>
+    - <doc:DefiningAFeature>
+    - <doc:TutorialBuildingALoginFlow>
+}

--- a/Sources/napkin/napkin.docc/napkin.md
+++ b/Sources/napkin/napkin.docc/napkin.md
@@ -64,6 +64,12 @@ A runnable end-to-end reference, **Napkin's Rib House**, lives at `Examples/RibH
 - <doc:DefiningAFeature>
 - <doc:MigratingFromV0>
 
+### Tutorials
+
+- <doc:TestingANapkin>
+- <doc:AddingANetworkedService>
+- <doc:TabBarNapkin>
+
 ### Architecture Reference
 
 - <doc:ProtocolCompositionOverInheritance>

--- a/Tools/site/llms.txt
+++ b/Tools/site/llms.txt
@@ -7,6 +7,9 @@
 - [Getting Started](https://getnapkin.to/documentation/napkin/gettingstarted): What a napkin is and how to bring napkin into a Swift package.
 - [Tutorial: Building a Login Flow](https://getnapkin.to/documentation/napkin/tutorialbuildingaloginflow): A guided walkthrough of the runnable example app (Napkin's Rib House) — service injection, parent + two children, listener pattern, snapshot tests.
 - [Defining a Feature](https://getnapkin.to/documentation/napkin/definingafeature): File-by-file walkthrough of building one viewable napkin with `@Snippet`-pulled code.
+- [Testing a Napkin](https://getnapkin.to/documentation/napkin/testinganapkin): Unit-test an actor-based interactor without booting a simulator. Mock presenter/router/listener, drive lifecycle, assert on recorded calls.
+- [Adding a Networked Service](https://getnapkin.to/documentation/napkin/addinganetworkedservice): Swap the example's BarbecueAuthService mock for a real URLSession-backed implementation. The napkin tree above the service doesn't change.
+- [Tab Bar Napkin](https://getnapkin.to/documentation/napkin/tabbarnapkin): Concurrent routing pattern — a parent napkin holds N child napkin builders, all attached at once, hosted in a UITabBarController.
 - [Migrating from V0](https://getnapkin.to/documentation/napkin/migratingfromv0): Side-by-side diffs for converting older RIBs/Combine code to napkin's Swift Concurrency idioms.
 
 ## Architecture

--- a/Tools/site/llms.txt
+++ b/Tools/site/llms.txt
@@ -1,0 +1,47 @@
+# napkin
+
+> A Swift 6.2 framework for building iOS & macOS apps as a tree of small, isolated, composable units ("napkins"). Modeled on Uber's RIBs, rebuilt around Swift Concurrency. Business logic lives in `final actor` interactors; routing and presentation are `@MainActor`; crossings are explicit.
+
+## Docs
+
+- [Getting Started](https://getnapkin.to/documentation/napkin/gettingstarted): What a napkin is and how to bring napkin into a Swift package.
+- [Tutorial: Building a Login Flow](https://getnapkin.to/documentation/napkin/tutorialbuildingaloginflow): A guided walkthrough of the runnable example app (Napkin's Rib House) — service injection, parent + two children, listener pattern, snapshot tests.
+- [Defining a Feature](https://getnapkin.to/documentation/napkin/definingafeature): File-by-file walkthrough of building one viewable napkin with `@Snippet`-pulled code.
+- [Migrating from V0](https://getnapkin.to/documentation/napkin/migratingfromv0): Side-by-side diffs for converting older RIBs/Combine code to napkin's Swift Concurrency idioms.
+
+## Architecture
+
+- [Protocol Composition Over Inheritance](https://getnapkin.to/documentation/napkin/protocolcompositionoverinheritance): Why napkin doesn't ship `open class PresentableInteractor<P>`; the SE-0306 / SE-0316 reasoning.
+- [Cross-Isolation Patterns](https://getnapkin.to/documentation/napkin/crossisolationpatterns): The four directional patterns for crossing actor boundaries (`await`, `dispatch`, etc.).
+- [Headless Napkins](https://getnapkin.to/documentation/napkin/headlessnapkins): When (and why) a napkin can be a pure orchestrator with no view.
+- [SwiftUI Integration](https://getnapkin.to/documentation/napkin/swiftuiintegration): `dispatch`, `UIHostingController` glue, accessibility identifiers.
+
+## API reference
+
+- [`Interactable`](https://getnapkin.to/documentation/napkin/interactable): the actor-typed business-logic ring.
+- [`PresentableInteractable`](https://getnapkin.to/documentation/napkin/presentableinteractable): interactor that owns a presenter.
+- [`InteractorLifecycle`](https://getnapkin.to/documentation/napkin/interactorlifecycle): the lifecycle helper interactors delegate to.
+- [`Routing`](https://getnapkin.to/documentation/napkin/routing), [`Router`](https://getnapkin.to/documentation/napkin/router): the routing primitives.
+- [`ViewableRouting`](https://getnapkin.to/documentation/napkin/viewablerouting), [`ViewableRouter`](https://getnapkin.to/documentation/napkin/viewablerouter): routers that own a view controller.
+- [`LaunchRouting`](https://getnapkin.to/documentation/napkin/launchrouting), [`LaunchRouter`](https://getnapkin.to/documentation/napkin/launchrouter): the root of the napkin tree.
+- [`ViewControllable`](https://getnapkin.to/documentation/napkin/viewcontrollable): platform view-controller bridge (`UIKit` / `AppKit`).
+- [`Presentable`](https://getnapkin.to/documentation/napkin/presentable): view-state holder protocol.
+
+## Examples
+
+- [Napkin's Rib House](https://github.com/WikipediaBrown/napkin/tree/main/Examples/RibHouse): Runnable iOS app — a headless `LaunchNapkin` holds an `AuthService`, swaps between a `LoggedOutNapkin` and a `LoggedInNapkin` on tap. Tracked `.xcodeproj` (no XcodeGen step required to open).
+
+## Project
+
+- [GitHub repository](https://github.com/WikipediaBrown/napkin)
+- [Latest release](https://github.com/WikipediaBrown/napkin/releases/latest)
+- [Releases feed (Atom)](https://github.com/WikipediaBrown/napkin/releases.atom)
+- [License: Apache 2.0](https://github.com/WikipediaBrown/napkin/blob/main/LICENSE.md)
+- [CHANGELOG](https://github.com/WikipediaBrown/napkin/blob/main/CHANGELOG.md)
+- [AGENTS.md (conventions for AI agents)](https://github.com/WikipediaBrown/napkin/blob/main/AGENTS.md)
+
+## Optional
+
+- [Swift Package Index listing](https://swiftpackageindex.com/WikipediaBrown/napkin): build status, Swift versions, supported platforms, hosted docs alternative.
+- [Marketing homepage](https://getnapkin.to/): overview and a 4-step animated tutorial of the example app.
+- [Full LLM-readable corpus](https://getnapkin.to/llms-full.txt): expanded version of this file with the full body text of each article inlined.


### PR DESCRIPTION
## Summary

A bundle of "everything except item 8" from the punch list. Two commits:

### Commit 1: Repo housekeeping

1. **\`AGENTS.md\`** at repo root — conventions for AI coding agents (folder layout, isolation rings, listener protocols, dispatch vs Task, build commands, iCloud warning). Idiomatic napkin guidance for every agent that touches the codebase.

2. **\`getnapkin.to/llms.txt\`** — LLM-readable site map. \`Tools/site/llms.txt\` is the source; \`Documentation.yml\` copies it on deploy.

3. **\`getnapkin.to/llms-full.txt\`** — generated at deploy time from \`napkin.md\` + every \`Articles/*.md\`. Stays in sync with the catalog automatically.

4. **CHANGELOG** entries for everything since 2.0.15 (custom domain, Sponsors, security analysis, RibHouse rename, snapshot tests, homepage Example section, DocC moss-green theme, CI case-collision fixes).

5. **\`Gemfile.lock\`** \`activesupport\` 8.1.2 → 8.1.3 — clears the 3 Dependabot security alerts.

### Commit 2: Three new tutorial articles

6. **\`TestingANapkin.md\`** — unit-test an actor interactor: mock the presenter/router/listener with final classes, drive lifecycle, assert on recorded calls. Covers leaf interactor and orchestrator patterns; explains how to wire a \`bundle.unit-test\` target.

7. **\`AddingANetworkedService.md\`** — swap the \`BarbecueAuthService\` mock for a \`URLSessionAuthService\`. Sendable + async + throws contract; \`URLSession.data(for:)\`; cancellation propagation; wiring at \`AppComponent\`; what *didn't* need to change.

8. **\`TabBarNapkin.md\`** — different routing pattern: N children attached concurrently and hosted in a \`UITabBarController\`. Build-once / attach-once in \`didLoad\`, when (and when not) selection state belongs in the interactor, swap vs tab-bar routing comparison.

All three are linked from a new "Tutorials" group in \`napkin.md\` and from \`llms.txt\`.

### Separately (no commit)

- Deleted the stale \`claude/remove-dead-code-016uryWhYA3M6iBXAoQwt8xF\` branch on origin. Repo now has only \`develop\`, \`main\`, and active feature branches.

## Test plan

- [ ] CI passes (Unit Tests, UI Tests, Analyze Swift, CodeQL)
- [ ] After deploy:
  - \`getnapkin.to/llms.txt\` returns the site map
  - \`getnapkin.to/llms-full.txt\` returns the concatenated catalog
  - \`getnapkin.to/documentation/napkin/testinganapkin\` renders
  - \`getnapkin.to/documentation/napkin/addinganetworkedservice\` renders
  - \`getnapkin.to/documentation/napkin/tabbarnapkin\` renders
- [ ] Dependabot alerts on \`activesupport\` close once the bump lands on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)