### PR TITLE
Playful 404 page

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -205,6 +205,8 @@ jobs:
           } > docs/llms-full.txt
           cp Tools/site/sitemap.xml docs/sitemap.xml
           cp Tools/site/robots.txt docs/robots.txt
+          # Custom 404 page. GitHub Pages serves /404.html on any 404.
+          cp Tools/site/404.html docs/404.html
           # Blog: 5 SEO-targeted long-form articles + listing page + Atom feed.
           # Hand-rolled HTML (no static-site-generator). Each post lives in
           # its own folder so the URL is `/blog/<slug>/`.

--- a/Tools/site/404.html
+++ b/Tools/site/404.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404 — This napkin's been used</title>
+    <meta name="description" content="The page you're looking for got tossed in the smoker. Here's what's still on the tray.">
+    <meta name="theme-color" content="#f6f1e3" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#0e1410" media="(prefers-color-scheme: dark)">
+    <meta name="robots" content="noindex">
+
+    <link rel="icon" type="image/png" sizes="48x48" href="/napkin-icon.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="/napkin-icon@2x.png">
+    <link rel="apple-touch-icon" href="/napkin-icon@2x.png">
+    <link rel="stylesheet" href="/styles.css">
+
+    <style>
+        .gone {
+            max-width: 760px;
+            margin: 0 auto;
+            padding: var(--s-7) clamp(1.25rem, 4vw, 4.5rem);
+            display: grid;
+            grid-template-columns: 1fr;
+            gap: var(--s-5);
+            align-items: center;
+        }
+        @media (min-width: 780px) {
+            .gone { grid-template-columns: 1fr 1fr; gap: var(--s-7); }
+        }
+        .gone__copy {}
+        .gone__title {
+            font-family: var(--font-serif);
+            font-size: var(--step-3);
+            line-height: 1.04;
+            letter-spacing: -0.025em;
+            margin: var(--s-2) 0 var(--s-3);
+            text-wrap: balance;
+        }
+        .gone__lede {
+            font-family: var(--font-serif);
+            font-size: var(--step-1);
+            line-height: 1.5;
+            color: var(--ink-2);
+            margin: 0 0 var(--s-4);
+        }
+        .gone__list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            border-top: 1px solid var(--rule);
+        }
+        .gone__list li {
+            border-bottom: 1px solid var(--rule);
+            padding: var(--s-3) 0;
+        }
+        .gone__list a {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: var(--s-3);
+            color: var(--ink);
+            text-decoration: none;
+            font-family: var(--font-serif);
+            font-size: var(--step-1);
+            transition: color 0.2s var(--easing);
+        }
+        .gone__list a:hover { color: var(--moss); }
+        .gone__list .arrow {
+            font-family: var(--font-mono);
+            font-size: var(--step--1);
+            color: var(--ink-3);
+            text-transform: uppercase;
+            letter-spacing: 0.18em;
+        }
+        .gone__list a:hover .arrow { color: var(--moss); }
+
+        .gone__art {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: var(--s-4);
+        }
+        .gone__art svg {
+            width: 100%;
+            max-width: 320px;
+            height: auto;
+            color: var(--moss);
+        }
+
+        /* Tiny wobble on the napkin so it feels alive but doesn't shout. */
+        @media (prefers-reduced-motion: no-preference) {
+            .gone__art svg {
+                animation: napkin-wobble 6s var(--easing) infinite;
+                transform-origin: 50% 60%;
+            }
+        }
+        @keyframes napkin-wobble {
+            0%, 100% { transform: rotate(-1deg); }
+            50%      { transform: rotate(2deg); }
+        }
+
+        .gone__big {
+            font-family: var(--font-serif);
+            font-style: italic;
+            font-size: clamp(6rem, 18vw, 12rem);
+            line-height: 1;
+            letter-spacing: -0.04em;
+            color: var(--moss);
+            margin: 0 0 var(--s-3);
+            opacity: 0.92;
+        }
+    </style>
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead" role="banner">
+    <div class="masthead__inner">
+        <a class="masthead__brand" href="/" aria-label="napkin — home">
+            <span class="masthead__mark" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M4 4 H20 V20 L4 20 L4 4 Z" />
+                    <path d="M4 14 L14 14 L14 20" />
+                </svg>
+            </span>
+            <span class="masthead__wordmark">napkin</span>
+        </a>
+        <nav class="masthead__nav" aria-label="Primary">
+            <ul>
+                <li><a href="/documentation/napkin/">Docs</a></li>
+                <li><a href="/#example">Example</a></li>
+                <li><a href="/blog/">Blog</a></li>
+                <li><a href="https://github.com/WikipediaBrown/napkin/blob/main/CHANGELOG.md">Changelog</a></li>
+                <li><a href="https://github.com/WikipediaBrown/napkin">GitHub</a></li>
+            </ul>
+        </nav>
+    </div>
+</header>
+
+<main id="main">
+<section class="gone" aria-labelledby="gone-title">
+    <div class="gone__copy">
+        <p class="post__kicker"><span>§ 04 04</span> <span class="sep">·</span> <span>Got smoked</span></p>
+        <p class="gone__big" aria-hidden="true">404</p>
+        <h1 class="gone__title" id="gone-title">This napkin's been used.</h1>
+        <p class="gone__lede">
+            Either the URL got tossed in the smoker or the page never existed. Either way, you're standing in the parking lot. Here's what's still on the tray:
+        </p>
+        <ul class="gone__list">
+            <li><a href="/"><span>Homepage</span><span class="arrow">→ start over</span></a></li>
+            <li><a href="/documentation/napkin/"><span>Documentation</span><span class="arrow">→ read the docs</span></a></li>
+            <li><a href="/blog/"><span>Blog</span><span class="arrow">→ five posts, real opinions</span></a></li>
+            <li><a href="/#example"><span>Napkin&#8217;s Rib House</span><span class="arrow">→ runnable example</span></a></li>
+            <li><a href="https://github.com/WikipediaBrown/napkin"><span>GitHub</span><span class="arrow">→ source &amp; issues</span></a></li>
+        </ul>
+    </div>
+
+    <div class="gone__art" aria-hidden="true">
+        <!-- A wrinkled paper napkin, hand-drawn-ish. The napkin n-mark logo
+             with a tear running through the bottom corner. -->
+        <svg viewBox="0 0 280 280" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
+            <!-- Outer napkin square, slightly wonky -->
+            <path d="M52 36 Q60 30 70 36 L222 38 Q232 40 232 50 L230 224 Q228 234 218 234 L62 230 Q50 230 50 218 L52 60 Z"
+                  stroke-width="2.4" />
+            <!-- Inner tab fold (the n-mark) -->
+            <path d="M58 156 L168 158 L170 224"
+                  stroke-width="2.4" />
+            <!-- Tear lines (where the page got smoked) -->
+            <path d="M170 230 L184 244 L176 252 L196 264 L188 274"
+                  stroke-width="1.8" stroke-dasharray="4 6" opacity="0.7" />
+            <!-- A wisp of smoke -->
+            <path d="M118 100 Q126 84 116 70 Q108 56 122 44"
+                  stroke-width="1.6" opacity="0.55" />
+            <path d="M148 108 Q156 92 146 78"
+                  stroke-width="1.4" opacity="0.4" />
+            <!-- "§" mark center, like a stamp -->
+            <text x="106" y="200"
+                  font-family="ui-serif, 'New York', Georgia, serif"
+                  font-style="italic" font-size="42" font-weight="500"
+                  fill="currentColor" stroke="none" opacity="0.85">n</text>
+        </svg>
+    </div>
+</section>
+</main>
+
+<footer class="colophon" role="contentinfo">
+    <div class="colophon__inner">
+        <p class="colophon__line">
+            <a class="link link--mono" href="https://github.com/WikipediaBrown/napkin">napkin</a>
+            <span aria-hidden="true" class="colophon__sep">·</span>
+            <a class="link link--mono" href="https://github.com/WikipediaBrown/napkin/blob/main/LICENSE.md">Apache&#8209;2.0</a>
+            <span aria-hidden="true" class="colophon__sep">·</span>
+            <a class="link link--mono" href="https://github.com/WikipediaBrown/napkin/blob/main/CHANGELOG.md">CHANGELOG</a>
+            <span aria-hidden="true" class="colophon__sep">·</span>
+            <a class="link link--mono" href="/blog/">Blog</a>
+            <span aria-hidden="true" class="colophon__sep">·</span>
+            <a class="link link--mono" href="/blog/feed.xml" type="application/atom+xml">RSS</a>
+        </p>
+        <p class="colophon__line colophon__line--right">
+            Made with 🌲🌲🌲 in Cascadia
+        </p>
+    </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

\`/404.html\` for GitHub Pages. Editorial styling matching the rest of the site:

- Kicker: \`§ 04 04 · Got smoked\`
- Big italic-serif \"404\" numerals in moss green
- Headline: \"This napkin's been used.\"
- Smoker-themed lede: \"Either the URL got tossed in the smoker or the page never existed. Either way, you're standing in the parking lot. Here's what's still on the tray:\"
- List of helpful links (homepage, docs, blog, example, GitHub), formatted like the blog index
- Hand-drawn SVG napkin with the n-mark logo, a couple of smoke wisps, and a dashed tear running off the bottom corner
- 6-second wobble animation on the SVG, gated on \`prefers-reduced-motion: no-preference\`
- \`<meta name=\"robots\" content=\"noindex\">\` so search engines don't index the 404 itself

## Wiring

\`Documentation.yml\` Copy step copies \`Tools/site/404.html\` to \`docs/404.html\`. GitHub Pages automatically serves \`/404.html\` on any 404.

## Test plan

- [ ] CI passes
- [ ] After merge to main + Documentation deploy, hit any nonexistent path on getnapkin.to (e.g. \`/foo/bar\`) and confirm the playful 404 renders with the masthead + footer + links

🤖 Generated with [Claude Code](https://claude.com/claude-code)