### PR TITLE
Add .nojekyll so /.well-known/security.txt is served

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -214,6 +214,11 @@ jobs:
           # /.well-known/security.txt — security disclosure pointer.
           mkdir -p docs/.well-known
           cp Tools/site/.well-known/security.txt docs/.well-known/security.txt
+          # GitHub Pages runs a Jekyll-style filter that excludes any path
+          # starting with `.` or `_` (so `.well-known/` would 404). A
+          # zero-byte `.nojekyll` at the site root disables that filter and
+          # serves every file verbatim.
+          touch docs/.nojekyll
           # Blog: 5 SEO-targeted long-form articles + listing page + Atom feed.
           # Hand-rolled HTML (no static-site-generator). Each post lives in
           # its own folder so the URL is `/blog/<slug>/`.


### PR DESCRIPTION
## Problem

After the discoverability deploy, every new page is live (\`/faq/\`, \`/recipes/\`, sitemap, Glossary DocC, FAQPage + SoftwareSourceCode schema) **except** \`/.well-known/security.txt\` → 404.

## Root cause

GitHub Pages runs a Jekyll-style filter even under Actions-based deployment (`actions/deploy-pages`). It excludes any file or directory whose name starts with \`.\` or \`_\`. The workflow copies \`security.txt\` into \`docs/.well-known/\` correctly, but Pages refuses to serve the dot-directory.

## Fix

\`touch docs/.nojekyll\` in the Copy step. A zero-byte \`.nojekyll\` at the site root disables the Jekyll filter and serves all paths verbatim.

## Test plan

- [ ] CI passes
- [ ] After merge + deploy, \`https://getnapkin.to/.well-known/security.txt\` returns 200
- [ ] All other pages still resolve (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)