### PR TITLE
Serve security.txt from site root, not /.well-known/

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -211,14 +211,12 @@ jobs:
           mkdir -p docs/faq docs/recipes
           cp Tools/site/faq/index.html docs/faq/index.html
           cp Tools/site/recipes/index.html docs/recipes/index.html
-          # /.well-known/security.txt — security disclosure pointer.
-          mkdir -p docs/.well-known
-          cp Tools/site/.well-known/security.txt docs/.well-known/security.txt
-          # GitHub Pages runs a Jekyll-style filter that excludes any path
-          # starting with `.` or `_` (so `.well-known/` would 404). A
-          # zero-byte `.nojekyll` at the site root disables that filter and
-          # serves every file verbatim.
-          touch docs/.nojekyll
+          # security.txt at the site ROOT (not /.well-known/). GitHub Pages
+          # reserves the /.well-known/ namespace for its own ACME / domain
+          # verification on custom domains and 404s anything else there
+          # (and dot-paths aren't served under workflow deploys regardless).
+          # /security.txt is the widely-accepted RFC 9116 fallback location.
+          cp Tools/site/security.txt docs/security.txt
           # Blog: 5 SEO-targeted long-form articles + listing page + Atom feed.
           # Hand-rolled HTML (no static-site-generator). Each post lives in
           # its own folder so the URL is `/blog/<slug>/`.

--- a/Tools/site/security.txt
+++ b/Tools/site/security.txt
@@ -2,6 +2,6 @@ Contact: https://github.com/WikipediaBrown/napkin/security/advisories/new
 Contact: mailto:security@spookylabs.ai
 Expires: 2027-12-31T23:59:59Z
 Preferred-Languages: en
-Canonical: https://getnapkin.to/.well-known/security.txt
+Canonical: https://getnapkin.to/security.txt
 Policy: https://github.com/WikipediaBrown/napkin/blob/main/SECURITY.md
 Acknowledgments: https://github.com/WikipediaBrown/napkin/blob/main/SECURITY.md


### PR DESCRIPTION
## Problem

\`https://getnapkin.to/.well-known/security.txt\` 404s in production. PR #124's \`.nojekyll\` fix didn't help.

## Root cause (confirmed)

- Under Actions-based GitHub Pages (\`build_type: workflow\`) there is **no Jekyll layer**, so \`.nojekyll\` is a no-op.
- GitHub Pages reserves \`/.well-known/\` for its own ACME / domain-verification handling on custom domains and 404s unknown files there.
- Separately, dot-prefixed paths aren't served under workflow deploys at all — both \`/.nojekyll\` and \`/.well-known/security.txt\` returned 404 while every non-dot path served fine.

## Fix

Move the file to \`Tools/site/security.txt\`, serve it at \`https://getnapkin.to/security.txt\` — the widely-accepted RFC 9116 fallback location that scanners also check. \`Canonical:\` field updated to match. Dropped the dead \`.well-known\` + \`.nojekyll\` workflow lines (PR #124's change is effectively reverted as part of this).

## Test plan

- [ ] CI passes
- [ ] After deploy, \`https://getnapkin.to/security.txt\` → 200 with the RFC 9116 content
- [ ] No regression on other pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)