### PR TITLE
Point RIBs links at uber/ribs-ios; harden Xcode template installer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Instructions for AI coding agents working in the napkin repository. Follow these
 
 ## What this project is
 
-napkin is a Swift 6.2 framework for clean-architecture iOS / macOS apps. It's a Swift Concurrency rewrite of Uber's [RIBs](https://github.com/uber/RIBs) — actors instead of base classes, `@MainActor` for routing/presentation, `Sendable` for everything that crosses an isolation boundary.
+napkin is a Swift 6.2 framework for clean-architecture iOS / macOS apps. It's a Swift Concurrency rewrite of Uber's [RIBs](https://github.com/uber/ribs-ios) — actors instead of base classes, `@MainActor` for routing/presentation, `Sendable` for everything that crosses an isolation boundary.
 
 Every feature is a **napkin**: a small unit composed of a fixed set of "rings" — Builder, Component, Interactor, Router, and (when there's a view) Presenter + ViewController. The pattern repeats across the framework; once you've written one napkin you've written all of them.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![License: Apache 2.0](https://img.shields.io/github/license/WikipediaBrown/napkin?color=blue)](https://github.com/WikipediaBrown/napkin/blob/main/LICENSE.md)
 [![Docs](https://img.shields.io/badge/docs-getnapkin.to-2dbe60)](https://getnapkin.to/documentation/napkin/)
 
-napkin is a fork of Uber's [RIBs](https://github.com/uber/RIBs) rebuilt on Swift 6.2 native concurrency. It structures iOS and macOS applications as a tree of modular units using the Router-Interactor-Builder pattern, with business logic running off the main actor and routing/presentation pinned to it.
+napkin is a fork of Uber's [RIBs](https://github.com/uber/ribs-ios) rebuilt on Swift 6.2 native concurrency. It structures iOS and macOS applications as a tree of modular units using the Router-Interactor-Builder pattern, with business logic running off the main actor and routing/presentation pinned to it.
 
 ## Table of Contents
 

--- a/Sources/napkin/napkin.docc/Articles/GettingStarted.md
+++ b/Sources/napkin/napkin.docc/Articles/GettingStarted.md
@@ -44,7 +44,7 @@ The napkin lifecycle is asynchronous from end to end:
 
 The name has two layers, both about being *clean*:
 
-1. napkin is a fork of Uber's [RIBs](https://github.com/uber/RIBs) with RxSwift removed — clean of Rx.
+1. napkin is a fork of Uber's [RIBs](https://github.com/uber/ribs-ios) with RxSwift removed — clean of Rx.
 2. napkin is an implementation of Clean Architecture — its dependency rule and isolation boundaries are enforced by Swift's type system and actor model.
 
 A "napkin," then, is a single feature unit composed of a builder, interactor, router, and (when the unit owns a view) a presenter and view. A napkin tree is just napkins composed under one another, with each parent attaching children and routing between them.

--- a/Sources/napkin/napkin.docc/Articles/ProtocolCompositionOverInheritance.md
+++ b/Sources/napkin/napkin.docc/Articles/ProtocolCompositionOverInheritance.md
@@ -4,7 +4,7 @@ Why napkin's interactors are protocol-conforming `final actor`s rather than subc
 
 ## Overview
 
-If you've used Uber's [RIBs](https://github.com/uber/RIBs) or any of its descendants, you remember the shape: `class FooInteractor: PresentableInteractor<FooPresentable> { override func didBecomeActive() { super.didBecomeActive(); … } }`. That base class held active-state, managed a disposable bag, and provided lifecycle hooks for subclasses to override.
+If you've used Uber's [RIBs](https://github.com/uber/ribs-ios) or any of its descendants, you remember the shape: `class FooInteractor: PresentableInteractor<FooPresentable> { override func didBecomeActive() { super.didBecomeActive(); … } }`. That base class held active-state, managed a disposable bag, and provided lifecycle hooks for subclasses to override.
 
 That shape is no longer available in modern Swift. This article is the complete reasoning behind the shape napkin landed on — protocol composition over inheritance — and the small kit of primitives that make it feel as ergonomic as the base class did.
 

--- a/Tools/InstallXcodeTemplates.sh
+++ b/Tools/InstallXcodeTemplates.sh
@@ -1,25 +1,42 @@
 #!/usr/bin/env sh
+set -eu
 
 # Configuration
 XCODE_TEMPLATE_DIR=$HOME'/Library/Developer/Xcode/Templates/File Templates/napkin'
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# Resolve this script's directory portably. The previous version used
+# ${BASH_SOURCE[0]} under a `#!/usr/bin/env sh` shebang — empty under a
+# real POSIX sh, which silently made SCRIPT_DIR the caller's cwd and copied
+# the wrong (or no) files while still reporting success. `$0` + dirname
+# works under both sh and bash, from any working directory. (Analogous to
+# uber/ribs-ios#37 — install scripts that fail silently on an unexpected
+# environment.)
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 PROJECT_NAME="napkin"
 
 # Copy napkin file templates into the local napkin template directory
 xcodeTemplate () {
-  echo "==> Removing previous napkin Xcode file templates."
+  SRC="$SCRIPT_DIR/$PROJECT_NAME"
+  if [ ! -d "$SRC" ]; then
+    echo "==> ERROR: template source not found at: $SRC" >&2
+    echo "    Run this script from a checkout of the napkin repo." >&2
+    exit 1
+  fi
 
+  echo "==> Removing previous napkin Xcode file templates."
   if [ -d "$XCODE_TEMPLATE_DIR" ]; then
     rm -R "$XCODE_TEMPLATE_DIR"
   fi
   mkdir -p "$XCODE_TEMPLATE_DIR"
 
   echo "==> Copying napkin Xcode file templates..."
-  cp -R "$SCRIPT_DIR"/"$PROJECT_NAME"/*.xctemplate "$XCODE_TEMPLATE_DIR"
-  cp -R "$SCRIPT_DIR"/"$PROJECT_NAME"/"$PROJECT_NAME".xctemplate/ownsView/* "$XCODE_TEMPLATE_DIR/$PROJECT_NAME.xctemplate/ownsViewwithXIB/"
-  cp -R "$SCRIPT_DIR"/"$PROJECT_NAME"/"Launch $PROJECT_NAME".xctemplate/ownsView/* "$XCODE_TEMPLATE_DIR/Launch $PROJECT_NAME.xctemplate/ownsViewwithXIB/"
-  cp -R "$SCRIPT_DIR"/"$PROJECT_NAME"/"$PROJECT_NAME".xctemplate/ownsView/* "$XCODE_TEMPLATE_DIR/$PROJECT_NAME.xctemplate/ownsViewwithStoryboard/"
-  cp -R "$SCRIPT_DIR"/"$PROJECT_NAME"/"Launch $PROJECT_NAME".xctemplate/ownsView/* "$XCODE_TEMPLATE_DIR/Launch $PROJECT_NAME.xctemplate/ownsViewwithStoryboard/"
+  # With `set -e` any failed cp (bad permissions, missing source, read-only
+  # destination) aborts the script with a non-zero status instead of
+  # falling through to "==> Success!".
+  cp -R "$SRC"/*.xctemplate "$XCODE_TEMPLATE_DIR"
+  cp -R "$SRC/$PROJECT_NAME.xctemplate/ownsView/"* "$XCODE_TEMPLATE_DIR/$PROJECT_NAME.xctemplate/ownsViewwithXIB/"
+  cp -R "$SRC/Launch $PROJECT_NAME.xctemplate/ownsView/"* "$XCODE_TEMPLATE_DIR/Launch $PROJECT_NAME.xctemplate/ownsViewwithXIB/"
+  cp -R "$SRC/$PROJECT_NAME.xctemplate/ownsView/"* "$XCODE_TEMPLATE_DIR/$PROJECT_NAME.xctemplate/ownsViewwithStoryboard/"
+  cp -R "$SRC/Launch $PROJECT_NAME.xctemplate/ownsView/"* "$XCODE_TEMPLATE_DIR/Launch $PROJECT_NAME.xctemplate/ownsViewwithStoryboard/"
 }
 
 xcodeTemplate

--- a/Tools/site/blog/swift-6-ribs-replacement/index.html
+++ b/Tools/site/blog/swift-6-ribs-replacement/index.html
@@ -68,10 +68,10 @@
 <article class="post">
     <p class="post__kicker"><span>§ 01</span> <span class="sep">·</span> <span>2026 · 05 · 15</span> <span class="sep">·</span> <span>Architecture</span></p>
     <h1 class="post__title">A RIBs alternative for Swift Concurrency, without RxSwift: meet napkin</h1>
-    <p class="post__lede">Uber's <a href="https://github.com/uber/RIBs">RIBs</a> is alive, well, and actively developed. It's also built on RxSwift and ships a runtime leak detector. napkin is the same Router-Interactor-Builder pattern written for Swift Concurrency, without either — Clean Architecture on a napkin.</p>
+    <p class="post__lede">Uber's <a href="https://github.com/uber/ribs-ios">RIBs</a> is alive, well, and actively developed. It's also built on RxSwift and ships a runtime leak detector. napkin is the same Router-Interactor-Builder pattern written for Swift Concurrency, without either — Clean Architecture on a napkin.</p>
 
     <div class="post__body">
-        <p>If you've shipped a non-trivial iOS app in the last five years, you've probably worked with <a href="https://github.com/uber/RIBs">RIBs</a>. The pattern is simple to describe and hard to fully internalize: every feature is a unit of <strong>Router</strong>, <strong>Interactor</strong>, and <strong>Builder</strong>, composed into a tree. The interactor is the unit's brain; the router owns the subtree; the builder constructs everything. A view, when there is one, lives behind a <code>Presentable</code> protocol that the interactor talks to.</p>
+        <p>If you've shipped a non-trivial iOS app in the last five years, you've probably worked with <a href="https://github.com/uber/ribs-ios">RIBs</a>. The pattern is simple to describe and hard to fully internalize: every feature is a unit of <strong>Router</strong>, <strong>Interactor</strong>, and <strong>Builder</strong>, composed into a tree. The interactor is the unit's brain; the router owns the subtree; the builder constructs everything. A view, when there is one, lives behind a <code>Presentable</code> protocol that the interactor talks to.</p>
 
         <p>RIBs is good. Uber still maintains it. Teams ship with it every day. This post isn't a "RIBs is dead" pitch — it isn't, and any post that tries to sell you that is selling something.</p>
 

--- a/Tools/site/faq/index.html
+++ b/Tools/site/faq/index.html
@@ -146,7 +146,7 @@
 
     <div class="post__body">
         <h2>What is napkin?</h2>
-        <p>napkin is a Swift 6.2 framework for building iOS and macOS apps as a tree of small, isolated, composable units called <em>napkins</em>. Each napkin is a Router-Interactor-Builder unit, modeled on Uber's <a href="https://github.com/uber/RIBs">RIBs</a> but rebuilt around Swift Concurrency. Business logic lives in <code>final actor</code> interactors. Routing and presentation are <code>@MainActor</code>. Crossings between isolation domains are explicit.</p>
+        <p>napkin is a Swift 6.2 framework for building iOS and macOS apps as a tree of small, isolated, composable units called <em>napkins</em>. Each napkin is a Router-Interactor-Builder unit, modeled on Uber's <a href="https://github.com/uber/ribs-ios">RIBs</a> but rebuilt around Swift Concurrency. Business logic lives in <code>final actor</code> interactors. Routing and presentation are <code>@MainActor</code>. Crossings between isolation domains are explicit.</p>
 
         <h2>How does napkin differ from Uber's RIBs?</h2>
         <p>napkin keeps the same vocabulary (Router, Interactor, Builder, Component, Listener, Presentable) and the same tree composition. It changes the underlying mechanics to fit Swift 6: interactors are <code>final actor</code> types instead of subclasses of an <code>open class</code>; routing protocols are <code>@MainActor</code> with <code>async</code> methods; reactive streams are <code>AsyncStream</code> instead of RxSwift <code>Observable</code>; there is no runtime leak detector. Both frameworks ship the same architecture pattern but make different trade-offs underneath.</p>

--- a/Tools/site/index.html
+++ b/Tools/site/index.html
@@ -113,7 +113,7 @@
         </h1>
 
         <p class="hero__lede">
-            <strong>napkin</strong> is a Swift 6.2 framework for clean-architecture iOS &amp; macOS apps, modeled on Uber's <a class="link" href="https://github.com/uber/RIBs">RIBs</a> and rebuilt around Swift Concurrency. Business logic lives in <code>final actor</code> interactors. Routing and presentation are <code>@MainActor</code>. Crossings are <em>explicit</em>.
+            <strong>napkin</strong> is a Swift 6.2 framework for clean-architecture iOS &amp; macOS apps, modeled on Uber's <a class="link" href="https://github.com/uber/ribs-ios">RIBs</a> and rebuilt around Swift Concurrency. Business logic lives in <code>final actor</code> interactors. Routing and presentation are <code>@MainActor</code>. Crossings are <em>explicit</em>.
         </p>
 
         <div class="cta-row">


### PR DESCRIPTION
Two changes from aligning with the now-iOS-specific RIBs repo.

## RIBs links → `uber/ribs-ios`
Uber split RIBs into a dedicated iOS repo ([`uber/ribs-ios`](https://github.com/uber/ribs-ios), actively maintained — last push 2026-04). All 8 napkin references pointed at the legacy combined `uber/RIBs`. Repointed: `README.md`, `AGENTS.md`, homepage, FAQ, the RIBs blog post, and the `GettingStarted` / `ProtocolCompositionOverInheritance` DocC articles.

## `InstallXcodeTemplates.sh` hardening — analog of [`uber/ribs-ios#37`](https://github.com/uber/ribs-ios/issues/37)
While triaging the `ribs-ios` issue tracker against napkin, #37 ("install-xcode-template fails if file permissions aren't exactly as expected") turned out to have a worse napkin analog:

- Script is `#!/usr/bin/env sh` but resolved its own path via `${BASH_SOURCE[0]}` — **empty under a real POSIX `sh`**, so `SCRIPT_DIR` silently became the caller's cwd and every `cp -R` copied the wrong thing.
- No `set -e` / no exit-code checks → it still printed **"==> Success!"** on total failure.

Fixed: `set -eu`, portable `$0`-based `SCRIPT_DIR` (works under sh *and* bash from any cwd), explicit source-missing guard. `sh -n` clean; resolution verified from an unrelated cwd.

## Issue triage summary (no other code changes needed)
The remaining 30 open `ribs-ios` issues do **not** plague napkin — most *validate* its design:
- **Swift 6 isolation (#43, still "in research"):** the `var listener` nonisolated-protocol-requirement error is structurally impossible in napkin — `Presentable` is a whole-protocol `@MainActor` and the listener lives on the interactor, not the presentable. napkin shipped the fix `ribs-ios` is still prototyping.
- **RxSwift / Combine (#44, #21, #31), LeakDetector (#17), async-await & SwiftUI conveniences (#6, #7), CocoaPods→SPM (#14, +5):** all N/A — these are napkin's reasons for existing.
- **Workflow `didComplete()` early (#39):** napkin has no `Workflow` type (Rx-based) — API surface doesn't exist.
- Tutorials/wiki/usage issues (#40, #29, #22, #36, #35, …): not framework defects; napkin's DocC pulls code via `@Snippet` from compiled sources, which structurally prevents the "tutorial contains an error" class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)