### PR TITLE
Blog post + README/site/docs: the Swift 6 listener-conformance seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Swift actors do not support inheritance (SE-0306). Rather than fall back to `@Ma
 
 Uber's `RIBs-iOS` PR #49 unifies the framework on `@MainActor` (Interactor included). napkin deliberately keeps the Interactor off the main actor so business logic is not pinned to the main thread. The cost is `await` at every cross-layer call; the benefit is enforced clean-architecture isolation.
 
+Both frameworks agree the *view-facing* seam belongs on `@MainActor`. napkin's base `Presentable` protocol is annotated `@MainActor`, so every feature's presentable (and any `var listener` it requires) inherits that isolation. The Swift 6 conformance error a RIB-shaped listener seam otherwise hits — *"Main actor-isolated property 'listener' cannot be used to satisfy nonisolated protocol requirement"* ([RIBs-iOS #43](https://github.com/uber/ribs-ios/issues/43)) — is therefore structurally impossible in napkin: the requirement and its `@MainActor` view-controller witness are always in the same isolation domain. The child-to-parent listener is a separate seam (an actor-isolated `weak var` behind a `Sendable async` protocol) and never had the problem. Full write-up: [The Swift 6 @MainActor listener-conformance error](https://getnapkin.to/blog/swift-6-mainactor-protocol-conformance/).
+
 ## Core Components
 
 ### Builder

--- a/Sources/napkin/Presenter.swift
+++ b/Sources/napkin/Presenter.swift
@@ -19,6 +19,15 @@ import Observation
 /// typically `async`: the interactor is an `actor`, the presenter is
 /// `@MainActor`, and crossing isolation domains requires `await`.
 ///
+/// Because the annotation lives on this base protocol, every feature
+/// `Presentable` — and any `var listener` requirement it declares — is
+/// `@MainActor`-isolated by inheritance. A `@MainActor` view controller
+/// therefore satisfies the conformance with requirement and witness in the
+/// same isolation domain, so the Swift 6 diagnostic *"Main actor-isolated
+/// property 'listener' cannot be used to satisfy nonisolated protocol
+/// requirement"* cannot arise for this seam. See
+/// <doc:CrossIsolationPatterns> for the full reasoning.
+///
 /// You have two options for who conforms to a feature-specific `Presentable`:
 ///
 /// - A dedicated ``Presenter`` subclass (recommended when there is non-trivial

--- a/Sources/napkin/napkin.docc/Articles/CrossIsolationPatterns.md
+++ b/Sources/napkin/napkin.docc/Articles/CrossIsolationPatterns.md
@@ -141,6 +141,23 @@ final actor HomeInteractor: PresentableInteractable, ProfileListener {
 
 **When you reach for it.** Whenever a child needs to tell its parent something happened that the parent owns the response to: a flow completed, the user dismissed a modal, a deep link resolved. The child never reaches up directly into the parent or its siblings; everything goes through the listener.
 
+## Why the view-facing seam is sound under Swift 6
+
+Patterns 3 and 4 both involve a "listener", but the two sit in different isolation domains — and that distinction is what keeps them clear of the Swift 6 conformance error *"Main actor-isolated property 'listener' cannot be used to satisfy nonisolated protocol requirement."*
+
+The **view-facing** listener (Pattern 3) is reached through a feature's ``Presentable`` protocol, and napkin's base ``Presentable`` is annotated `@MainActor`:
+
+```swift
+@MainActor
+public protocol Presentable: AnyObject {}
+```
+
+Every feature presentable refines it, so the whole protocol — including any `var listener` requirement declared on it — is `@MainActor`-isolated by inheritance. The conforming view controller is `@MainActor` too. Requirement and witness share one isolation domain, so the conformance is sound *by construction*: there is no per-feature isolation annotation to remember, and no nonisolated requirement for a main-actor witness to fail against.
+
+The **child-to-parent** listener (Pattern 4) is not a protocol a view witnesses across a boundary at all. It is a stored `weak var` on the interactor actor, and the listener protocol is `Sendable` with `async` methods, so calling it is an ordinary explicit crossing into the parent's actor. It never had the isolation-mismatch problem because it was never a cross-isolation protocol witness.
+
+The general lesson: assign the view-facing seam an isolation domain *at the base protocol*, once, and every refinement inherits a sound conformance. See <doc:ProtocolCompositionOverInheritance> for the same principle applied to the interactor.
+
 ## When to use `task(_:)` vs an unstructured `Task`
 
 Inside an interactor you have two ways to spawn concurrent work. They are not interchangeable.

--- a/Tools/site/blog/feed.xml
+++ b/Tools/site/blog/feed.xml
@@ -5,12 +5,21 @@
     <link rel="alternate" href="https://getnapkin.to/blog/"/>
     <link rel="self" href="https://getnapkin.to/blog/feed.xml"/>
     <id>https://getnapkin.to/blog/</id>
-    <updated>2026-05-15T00:00:00Z</updated>
+    <updated>2026-05-16T00:00:00Z</updated>
     <icon>https://getnapkin.to/napkin-icon.png</icon>
     <author>
         <name>napkin</name>
         <uri>https://getnapkin.to/</uri>
     </author>
+
+    <entry>
+        <title>The Swift 6 @MainActor listener-conformance error, and a seam that sidesteps it</title>
+        <link href="https://getnapkin.to/blog/swift-6-mainactor-protocol-conformance/"/>
+        <id>https://getnapkin.to/blog/swift-6-mainactor-protocol-conformance/</id>
+        <updated>2026-05-16T00:00:00Z</updated>
+        <published>2026-05-16T00:00:00Z</published>
+        <summary>"Main actor-isolated property 'listener' cannot be used to satisfy nonisolated protocol requirement" is the error every RIB-shaped listener seam hits under Swift 6. Why it happens, and the whole-protocol @MainActor design that makes it structurally impossible.</summary>
+    </entry>
 
     <entry>
         <title>A RIBs alternative for Swift Concurrency, without RxSwift: meet napkin</title>

--- a/Tools/site/blog/index.html
+++ b/Tools/site/blog/index.html
@@ -63,6 +63,15 @@
 
     <ol class="blog__list">
         <li class="post-card">
+            <p class="post-card__meta">2026 · 05 · 16</p>
+            <div class="post-card__body">
+                <h2 class="post-card__title"><a href="/blog/swift-6-mainactor-protocol-conformance/">The Swift 6 @MainActor listener-conformance error, and a seam that sidesteps it</a></h2>
+                <p class="post-card__excerpt">"Main actor-isolated property 'listener' cannot be used to satisfy nonisolated protocol requirement" is the error every RIB-shaped listener seam hits under Swift 6. Why it happens, and the whole-protocol @MainActor design that makes it structurally impossible.</p>
+                <a class="post-card__tag" href="/blog/swift-6-mainactor-protocol-conformance/">Read</a>
+            </div>
+        </li>
+
+        <li class="post-card">
             <p class="post-card__meta">2026 · 05 · 15</p>
             <div class="post-card__body">
                 <h2 class="post-card__title"><a href="/blog/swift-6-ribs-replacement/">A RIBs alternative for Swift Concurrency, without RxSwift: meet napkin</a></h2>

--- a/Tools/site/blog/modular-ios-apps-swift-concurrency/index.html
+++ b/Tools/site/blog/modular-ios-apps-swift-concurrency/index.html
@@ -66,7 +66,7 @@
 
 <main id="main">
 <article class="post">
-    <p class="post__kicker"><span>§ 05</span> <span class="sep">·</span> <span>2026 · 05 · 01</span> <span class="sep">·</span> <span>Modularity</span></p>
+    <p class="post__kicker"><span>§ 06</span> <span class="sep">·</span> <span>2026 · 05 · 01</span> <span class="sep">·</span> <span>Modularity</span></p>
     <h1 class="post__title">Modular iOS apps with Swift Concurrency</h1>
     <p class="post__lede">Modularity isn't a build-system question. It's about whether features can be reasoned about in isolation — read alone, tested alone, replaced alone.</p>
 

--- a/Tools/site/blog/swift-6-actor-isolation-architecture/index.html
+++ b/Tools/site/blog/swift-6-actor-isolation-architecture/index.html
@@ -66,7 +66,7 @@
 
 <main id="main">
 <article class="post">
-    <p class="post__kicker"><span>§ 02</span> <span class="sep">·</span> <span>2026 · 05 · 12</span> <span class="sep">·</span> <span>Concurrency</span></p>
+    <p class="post__kicker"><span>§ 03</span> <span class="sep">·</span> <span>2026 · 05 · 12</span> <span class="sep">·</span> <span>Concurrency</span></p>
     <h1 class="post__title">Actor isolation for iOS app architecture in Swift 6</h1>
     <p class="post__lede">Swift 6 makes you declare where every piece of code runs. That's an architecture decision in disguise — and most apps haven't made it explicitly before.</p>
 

--- a/Tools/site/blog/swift-6-mainactor-protocol-conformance/index.html
+++ b/Tools/site/blog/swift-6-mainactor-protocol-conformance/index.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>The Swift 6 @MainActor listener-conformance error, and a seam that sidesteps it</title>
+    <meta name="description" content="&quot;Main actor-isolated property 'listener' cannot be used to satisfy nonisolated protocol requirement&quot; is the error every RIB-shaped listener seam hits under Swift 6. Here's why it happens and the whole-protocol @MainActor design that makes it structurally impossible.">
+    <meta name="theme-color" content="#f6f1e3" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#0e1410" media="(prefers-color-scheme: dark)">
+
+    <meta property="og:title" content="The Swift 6 @MainActor listener-conformance error, and a seam that sidesteps it">
+    <meta property="og:description" content="Why the RIB listener seam hits &quot;Main actor-isolated property cannot be used to satisfy nonisolated protocol requirement&quot; under Swift 6 — and the whole-protocol @MainActor design that makes it structurally impossible.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://getnapkin.to/blog/swift-6-mainactor-protocol-conformance/">
+    <meta property="og:image" content="https://getnapkin.to/social-preview.png">
+    <meta property="article:published_time" content="2026-05-16">
+    <meta name="twitter:card" content="summary_large_image">
+    <link rel="canonical" href="https://getnapkin.to/blog/swift-6-mainactor-protocol-conformance/">
+
+    <link rel="icon" type="image/png" sizes="48x48" href="/napkin-icon.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="/napkin-icon@2x.png">
+    <link rel="apple-touch-icon" href="/napkin-icon@2x.png">
+    <link rel="alternate" type="application/atom+xml" title="napkin blog" href="/blog/feed.xml">
+    <link rel="stylesheet" href="/styles.css">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "The Swift 6 @MainActor listener-conformance error, and a seam that sidesteps it",
+        "description": "Why the RIB listener seam hits \"Main actor-isolated property cannot be used to satisfy nonisolated protocol requirement\" under Swift 6, and the whole-protocol @MainActor design that makes it structurally impossible.",
+        "datePublished": "2026-05-16",
+        "author": { "@type": "Organization", "name": "napkin" },
+        "publisher": { "@type": "Organization", "name": "napkin", "url": "https://getnapkin.to/" },
+        "image": "https://getnapkin.to/social-preview.png",
+        "mainEntityOfPage": "https://getnapkin.to/blog/swift-6-mainactor-protocol-conformance/"
+    }
+    </script>
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead" role="banner">
+    <div class="masthead__inner">
+        <a class="masthead__brand" href="/" aria-label="napkin — home">
+            <span class="masthead__mark" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M4 4 H20 V20 L4 20 L4 4 Z" />
+                    <path d="M4 14 L14 14 L14 20" />
+                </svg>
+            </span>
+            <span class="masthead__wordmark">napkin</span>
+        </a>
+        <nav class="masthead__nav" aria-label="Primary">
+            <ul>
+                <li><a href="/documentation/napkin/">Docs</a></li>
+                <li><a href="/#example">Example</a></li>
+                <li><a href="/blog/" aria-current="page">Blog</a></li>
+                <li><a href="/changelog/">Changelog</a></li>
+                <li><a href="https://github.com/WikipediaBrown/napkin">GitHub</a></li>
+            </ul>
+        </nav>
+    </div>
+</header>
+
+<main id="main">
+<article class="post">
+    <p class="post__kicker"><span>§ 01</span> <span class="sep">·</span> <span>2026 · 05 · 16</span> <span class="sep">·</span> <span>Concurrency</span></p>
+    <h1 class="post__title">The Swift 6 @MainActor listener-conformance error, and a seam that sidesteps it</h1>
+    <p class="post__lede">If you've migrated a Router-Interactor-Builder codebase to Swift 6, you've probably met this one: <em>"Main actor-isolated property 'listener' cannot be used to satisfy nonisolated protocol requirement."</em> It's not a bug in your code. It's a seam that was never assigned an isolation domain — and there's a way to design it so the error can't occur.</p>
+
+    <div class="post__body">
+        <p>The Router-Interactor-Builder pattern has a listener seam: a view forwards user events "up" to the unit that owns the decision. The classic shape is a presentable protocol the view conforms to, plus a back-reference to a listener it calls. It compiled cleanly for years. Under Swift 6 strict concurrency it often doesn't:</p>
+
+        <figure class="code-card" aria-label="The Swift 6 conformance error">
+            <figcaption class="code-card__cap">
+                <span class="code-card__dots" aria-hidden="true"><span></span><span></span><span></span></span>
+                <span class="code-card__name">error</span>
+            </figcaption>
+<pre><code>Main actor-isolated property 'listener' cannot be used
+to satisfy nonisolated protocol requirement
+</code></pre>
+        </figure>
+
+        <p>This is not a niche edge case. It's the headline open Swift 6 question on Uber's actively-maintained <a href="https://github.com/uber/ribs-ios/issues/43">RIBs-iOS issue #43</a>, and it shows up in nearly every codebase that adopts a RIB-shaped listener seam and then turns on the Swift 6 language mode.</p>
+
+        <h2>Why the seam triggers it</h2>
+
+        <p>The error is the compiler asking a question the original design never answered: <em>which isolation domain does the listener live in?</em></p>
+
+        <p>The view layer is <code>@MainActor</code> — that part was never in doubt; UIKit and SwiftUI require it. So when a view controller conforms to a presentable protocol, the view controller's members are main-actor-isolated. But the <em>protocol requirement</em> it's satisfying — <code>var listener: PresentableListener? { get set }</code>, declared on a protocol with no isolation annotation — is <code>nonisolated</code>. Swift 6 will not let a main-actor-isolated property be the witness for a nonisolated requirement, because a caller holding only the protocol type could touch <code>listener</code> from any executor.</p>
+
+        <figure class="code-card" aria-label="The shape that fails under Swift 6">
+            <figcaption class="code-card__cap">
+                <span class="code-card__dots" aria-hidden="true"><span></span><span></span><span></span></span>
+                <span class="code-card__name">Fails under Swift 6</span>
+            </figcaption>
+<pre><code>// No isolation on the protocol → requirement is nonisolated.
+protocol HomePresentable: AnyObject {
+    var listener: HomePresentableListener? { get set }
+}
+
+@MainActor                                  // views must be @MainActor
+final class HomeViewController: UIViewController, HomePresentable {
+    weak var listener: HomePresentableListener?
+    // ❌ Main actor-isolated property 'listener' cannot be used
+    //    to satisfy nonisolated protocol requirement
+}
+</code></pre>
+        </figure>
+
+        <p>You can paper over it — annotate the witness <code>nonisolated</code>, sprinkle <code>@preconcurrency</code>, or hop through a <code>Task&nbsp;{&nbsp;@MainActor&nbsp;in&nbsp;… }</code>. Each one trades a compiler error for a runtime question mark, and the seam still has no declared home. The real fix is to give it one.</p>
+
+        <h2>The fix everyone converges on</h2>
+
+        <p>The view-facing seam should be <code>@MainActor</code>. That's not a workaround — it's the truth. The presenter, the view controller, and the listener handle that the view holds all live where the view lives. RIBs-iOS is landing exactly this conclusion: <a href="https://github.com/uber/ribs-ios/issues/43">issue #43</a>'s research and the follow-on PR move the framework's view-side types onto <code>@MainActor</code>. It's the right call, and it's a non-trivial one to retrofit into a framework whose API has to stay source-compatible for everyone already shipping on it.</p>
+
+        <p>napkin had the advantage of starting after Swift 6, so it could make that decision once, at the bottom, and never special-case it again.</p>
+
+        <h2>napkin's version: annotate the base protocol, once</h2>
+
+        <p>napkin's base <code>Presentable</code> protocol is a single annotated line:</p>
+
+        <figure class="code-card" aria-label="napkin's base Presentable protocol">
+            <figcaption class="code-card__cap">
+                <span class="code-card__dots" aria-hidden="true"><span></span><span></span><span></span></span>
+                <span class="code-card__name">Presenter.swift</span>
+                <button class="code-card__copy" type="button" data-copy>Copy</button>
+            </figcaption>
+<pre><code>@MainActor
+public protocol Presentable: AnyObject {}
+</code></pre>
+        </figure>
+
+        <p>Every feature's presentable seam refines that protocol — so it inherits the isolation. There is no per-feature, per-property annotation to remember and no place to forget one:</p>
+
+        <figure class="code-card" aria-label="A feature presentable inherits @MainActor">
+            <figcaption class="code-card__cap">
+                <span class="code-card__dots" aria-hidden="true"><span></span><span></span><span></span></span>
+                <span class="code-card__name">HomePresentable.swift</span>
+                <button class="code-card__copy" type="button" data-copy>Copy</button>
+            </figcaption>
+<pre><code>// Refines Presentable → the whole protocol, including any
+// `var listener` requirement, is @MainActor by inheritance.
+protocol HomePresentable: Presentable {
+    func presentUser(_ user: User) async
+}
+
+@MainActor
+final class HomeViewController: UIViewController, HomePresentable {
+    weak var listener: HomePresentableListener?
+    // ✅ requirement is @MainActor; witness is @MainActor. No mismatch.
+}
+</code></pre>
+        </figure>
+
+        <p>The requirement and the witness are now in the same isolation domain by construction. The error isn't suppressed — it's <em>unreachable</em>. You cannot write the failing shape in napkin without first un-annotating a framework protocol.</p>
+
+        <h2>Two listeners, two directions, both sound</h2>
+
+        <p>"Listener" means two different seams in a RIB tree, and it's worth being precise about which one the error is about.</p>
+
+        <ol>
+            <li><strong>View → interactor</strong> — the <em>presentable</em> listener. The view holds it and forwards taps. This is the one that hit the Swift 6 error, and it's sound in napkin because the whole <code>Presentable</code> protocol is <code>@MainActor</code>.</li>
+            <li><strong>Interactor → parent</strong> — the <em>child-to-parent</em> listener. A child interactor signals an event up to whichever parent built it.</li>
+        </ol>
+
+        <p>The second one never had the problem, for a different structural reason. It isn't a protocol requirement a view witnesses across an isolation boundary — it's a plain stored property on the interactor actor, and the listener protocol itself is <code>Sendable</code> with <code>async</code> methods so the call legitimately crosses into the parent's actor:</p>
+
+        <figure class="code-card" aria-label="Child-to-parent listener seam">
+            <figcaption class="code-card__cap">
+                <span class="code-card__dots" aria-hidden="true"><span></span><span></span><span></span></span>
+                <span class="code-card__name">ProfileInteractor.swift</span>
+                <button class="code-card__copy" type="button" data-copy>Copy</button>
+            </figcaption>
+<pre><code>protocol ProfileListener: AnyObject, Sendable {
+    func profileDidFinish() async
+}
+
+final actor ProfileInteractor: PresentableInteractable {
+    weak var listener: ProfileListener?          // actor-isolated property
+
+    func didTapDone() async {
+        await listener?.profileDidFinish()       // explicit crossing
+    }
+}
+</code></pre>
+        </figure>
+
+        <p>Neither direction can produce the nonisolated-witness error: one because the seam is uniformly <code>@MainActor</code>, the other because it isn't a cross-isolation protocol witness at all. <a href="/documentation/napkin/crossisolationpatterns">The full pattern reference is in the docs.</a></p>
+
+        <h2>Where napkin agrees with RIBs-iOS, and where it doesn't</h2>
+
+        <p>napkin and RIBs-iOS reach the same conclusion about the <em>view</em> seam: it belongs on the main actor. The deliberate divergence is one ring deeper. RIBs-iOS's modernization unifies the framework on <code>@MainActor</code> including the interactor; napkin keeps the interactor as a <code>final actor</code> <em>off</em> the main actor, so business logic is never scheduled behind UIKit's executor.</p>
+
+        <p>That's the Clean Architecture dependency rule expressed in Swift's isolation system: UI (outer) may depend on business rules (inner), never the reverse. Putting the interactor on <code>@MainActor</code> would compile, but it would structurally bind every decision your app makes to the UI thread — the inversion the architecture exists to prevent. The cost of keeping them separate is an <code>await</code> at each crossing; the benefit is that the boundary is real and the compiler enforces it. <a href="/documentation/napkin/protocolcompositionoverinheritance">The reasoning is laid out in full here.</a></p>
+
+        <p>Both frameworks ship the same pattern. RIBs is alive, well, and actively working through Swift 6 adoption on a public API it has to keep stable. napkin is the same Router-Interactor-Builder shape with the isolation decisions made up front — Clean Architecture on a napkin.</p>
+
+        <h2>The takeaway</h2>
+
+        <p>If you're hitting <em>"cannot be used to satisfy nonisolated protocol requirement"</em> on your own listener seam, the durable fix isn't a <code>nonisolated</code> annotation on the witness — it's deciding, once, that the view-facing protocol is <code>@MainActor</code>, and annotating it at the lowest point so every refinement inherits it. Suppress the error and the seam still has no home; annotate the protocol and the question is answered everywhere at once.</p>
+
+        <p>Want to see it end to end? The <a href="https://github.com/WikipediaBrown/napkin/tree/main/Examples/RibHouse">Rib House example</a> is a few hundred lines, and the <a href="/documentation/napkin/tutorialbuildingaloginflow">tutorial walks the seam</a>.</p>
+    </div>
+
+    <footer class="post__footer">
+        <p><a href="/blog/">← All posts</a></p>
+        <p>napkin · <a href="/documentation/napkin/">Docs</a> · <a href="https://github.com/WikipediaBrown/napkin">GitHub</a></p>
+    </footer>
+</article>
+</main>
+
+<footer class="colophon" role="contentinfo">
+    <div class="colophon__inner">
+        <p class="colophon__line">
+            <a class="link link--mono" href="https://github.com/WikipediaBrown/napkin">napkin</a>
+            <span aria-hidden="true" class="colophon__sep">·</span>
+            <a class="link link--mono" href="https://github.com/WikipediaBrown/napkin/blob/main/LICENSE.md">Apache&#8209;2.0</a>
+            <span aria-hidden="true" class="colophon__sep">·</span>
+            <a class="link link--mono" href="/changelog/">CHANGELOG</a>
+            <span aria-hidden="true" class="colophon__sep">·</span>
+            <a class="link link--mono" href="/blog/">Blog</a>
+            <span aria-hidden="true" class="colophon__sep">·</span>
+            <a class="link link--mono" href="/blog/feed.xml" type="application/atom+xml">RSS</a>
+        </p>
+        <p class="colophon__line colophon__line--right">
+            Made with 🌲🌲🌲 in Cascadia
+        </p>
+    </div>
+</footer>
+
+<script>
+(function() {
+    document.querySelectorAll('button[data-copy]').forEach(function(btn) {
+        btn.addEventListener('click', async function() {
+            var card = btn.closest('.code-card');
+            var code = card && card.querySelector('pre code');
+            if (!code) return;
+            try {
+                await navigator.clipboard.writeText(code.innerText);
+                var prev = btn.textContent;
+                btn.setAttribute('data-state', 'copied');
+                btn.textContent = 'Copied';
+                setTimeout(function() {
+                    btn.removeAttribute('data-state');
+                    btn.textContent = prev;
+                }, 1400);
+            } catch (e) { btn.textContent = 'Copy failed'; }
+        });
+    });
+})();
+</script>
+
+</body>
+</html>

--- a/Tools/site/blog/swift-6-ribs-replacement/index.html
+++ b/Tools/site/blog/swift-6-ribs-replacement/index.html
@@ -66,7 +66,7 @@
 
 <main id="main">
 <article class="post">
-    <p class="post__kicker"><span>§ 01</span> <span class="sep">·</span> <span>2026 · 05 · 15</span> <span class="sep">·</span> <span>Architecture</span></p>
+    <p class="post__kicker"><span>§ 02</span> <span class="sep">·</span> <span>2026 · 05 · 15</span> <span class="sep">·</span> <span>Architecture</span></p>
     <h1 class="post__title">A RIBs alternative for Swift Concurrency, without RxSwift: meet napkin</h1>
     <p class="post__lede">Uber's <a href="https://github.com/uber/ribs-ios">RIBs</a> is alive, well, and actively developed. It's also built on RxSwift and ships a runtime leak detector. napkin is the same Router-Interactor-Builder pattern written for Swift Concurrency, without either — Clean Architecture on a napkin.</p>
 

--- a/Tools/site/blog/swiftui-dependency-injection-without-libraries/index.html
+++ b/Tools/site/blog/swiftui-dependency-injection-without-libraries/index.html
@@ -66,7 +66,7 @@
 
 <main id="main">
 <article class="post">
-    <p class="post__kicker"><span>§ 03</span> <span class="sep">·</span> <span>2026 · 05 · 08</span> <span class="sep">·</span> <span>DI</span></p>
+    <p class="post__kicker"><span>§ 04</span> <span class="sep">·</span> <span>2026 · 05 · 08</span> <span class="sep">·</span> <span>DI</span></p>
     <h1 class="post__title">Dependency injection in SwiftUI without third-party libraries</h1>
     <p class="post__lede">SwiftUI's <code>@Environment</code> wasn't designed for services. <code>@EnvironmentObject</code> crashes at runtime when you forget. There's a third option that's been around since RIBs and works cleanly with Swift 6 actors.</p>
 

--- a/Tools/site/blog/testing-swift-actors-guide/index.html
+++ b/Tools/site/blog/testing-swift-actors-guide/index.html
@@ -88,7 +88,7 @@
 
 <main id="main">
 <article class="post">
-    <p class="post__kicker"><span>§ 04</span> <span class="sep">·</span> <span>2026 · 05 · 05</span> <span class="sep">·</span> <span>Testing</span></p>
+    <p class="post__kicker"><span>§ 05</span> <span class="sep">·</span> <span>2026 · 05 · 05</span> <span class="sep">·</span> <span>Testing</span></p>
     <h1 class="post__title">Testing Swift actors: a practical guide</h1>
     <p class="post__lede">Swift actors are easy to test, in the same way protocols are. The trick is to stop trying to mock the actor and start mocking what it talks to.</p>
 

--- a/Tools/site/faq/index.html
+++ b/Tools/site/faq/index.html
@@ -104,6 +104,11 @@
             },
             {
                 "@type": "Question",
+                "name": "Does napkin hit the Swift 6 'Main actor-isolated property cannot be used to satisfy nonisolated protocol requirement' error?",
+                "acceptedAnswer": { "@type": "Answer", "text": "No, and it cannot. napkin's base Presentable protocol is annotated @MainActor, so every feature's presentable seam — including any var listener requirement on it — inherits that isolation. The @MainActor view controller that witnesses the requirement is then in the same isolation domain, so the error is structurally impossible rather than suppressed. This is the headline Swift 6 question on Uber's actively-maintained RIBs-iOS (issue #43); napkin's whole-protocol @MainActor design avoids it by construction. The other listener seam, child-to-parent, is a separate thing — an actor-isolated weak property behind a Sendable async protocol — and never had the problem. Full write-up at https://getnapkin.to/blog/swift-6-mainactor-protocol-conformance/." }
+            },
+            {
+                "@type": "Question",
                 "name": "Where can I find the docs?",
                 "acceptedAnswer": { "@type": "Answer", "text": "Full documentation at https://getnapkin.to/documentation/napkin/. Architecture articles (Cross-Isolation Patterns, Protocol Composition Over Inheritance), tutorials (Building a Login Flow, Testing a Napkin, Adding a Networked Service, Tab Bar Napkin), and full API reference. The repository is at https://github.com/WikipediaBrown/napkin." }
             }
@@ -191,6 +196,9 @@
 
         <h2>How does napkin handle Swift 6 strict concurrency?</h2>
         <p>By design, not by suppression. Every cross-isolation crossing is explicit: actor → <code>@MainActor</code> uses <code>await</code>, view → actor uses the <code>dispatch</code> helper, parent listener calls use <code>await</code>. There are no <code>@unchecked Sendable</code> hacks on the hot path. The compiler errors that Swift 6 raises are taken as architecture signals — they tell you where data flows between isolation domains, which is exactly where the boundaries should be.</p>
+
+        <h2>Does napkin hit the Swift 6 &ldquo;Main actor-isolated property cannot be used to satisfy nonisolated protocol requirement&rdquo; error?</h2>
+        <p>No, and it can&rsquo;t. napkin&rsquo;s base <code>Presentable</code> protocol is annotated <code>@MainActor</code>, so every feature&rsquo;s presentable seam — including any <code>var listener</code> requirement on it — inherits that isolation. The <code>@MainActor</code> view controller that witnesses the requirement is then in the same isolation domain, so the error is <em>structurally impossible</em> rather than suppressed. This is the headline Swift 6 question on Uber&rsquo;s actively-maintained <a href="https://github.com/uber/ribs-ios/issues/43">RIBs-iOS (issue&nbsp;#43)</a>; napkin&rsquo;s whole-protocol <code>@MainActor</code> design avoids it by construction. The child-to-parent listener is a separate seam — an actor-isolated <code>weak</code> property behind a <code>Sendable</code> <code>async</code> protocol — and never had the problem. Full write-up: <a href="/blog/swift-6-mainactor-protocol-conformance/">The Swift 6 @MainActor listener-conformance error</a>.</p>
 
         <h2>Where can I find the docs?</h2>
         <p>Full documentation at <a href="/documentation/napkin/">getnapkin.to/documentation/napkin/</a>. Architecture articles (<a href="/documentation/napkin/crossisolationpatterns">Cross-Isolation Patterns</a>, <a href="/documentation/napkin/protocolcompositionoverinheritance">Protocol Composition Over Inheritance</a>), tutorials (<a href="/documentation/napkin/tutorialbuildingaloginflow">Building a Login Flow</a>, <a href="/documentation/napkin/testinganapkin">Testing a Napkin</a>, <a href="/documentation/napkin/addinganetworkedservice">Adding a Networked Service</a>, <a href="/documentation/napkin/tabbarnapkin">Tab Bar Napkin</a>), and full API reference. The repository is at <a href="https://github.com/WikipediaBrown/napkin">github.com/WikipediaBrown/napkin</a>.</p>

--- a/Tools/site/sitemap.xml
+++ b/Tools/site/sitemap.xml
@@ -31,6 +31,12 @@
         <priority>0.7</priority>
     </url>
     <url>
+        <loc>https://getnapkin.to/blog/swift-6-mainactor-protocol-conformance/</loc>
+        <lastmod>2026-05-16</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.7</priority>
+    </url>
+    <url>
         <loc>https://getnapkin.to/blog/swift-6-ribs-replacement/</loc>
         <lastmod>2026-05-15</lastmod>
         <changefreq>monthly</changefreq>


### PR DESCRIPTION
Writes up the `#43` finding from the earlier `ribs-ios` triage as a proper blog post, and threads the same point through the README, site, and docs.

## New blog post
`/blog/swift-6-mainactor-protocol-conformance/` — **"The Swift 6 @MainActor listener-conformance error, and a seam that sidesteps it."** Explains the `"Main actor-isolated property 'listener' cannot be used to satisfy nonisolated protocol requirement"` error, why a RIB-shaped listener seam triggers it under Swift 6, and how napkin's whole-protocol `@MainActor Presentable` makes it structurally impossible (vs. suppressed). Two-listener distinction (view→interactor vs child→parent) made explicit.

**Positioning (house rules respected):** RIBs/RIBs-iOS is alive and actively maintained; it's landing the *same* view-seam conclusion ([issue #43](https://github.com/uber/ribs-ios/issues/43) / PR #49) on an API it must keep source-stable. napkin's deliberate divergence is keeping the *interactor* off `@MainActor` — the clean-architecture dependency rule. "Clean Architecture on a napkin."

## Plumbing
- `blog/index.html` new card; `feed.xml` new entry + `<updated>` bump; `sitemap.xml` new `<url>`
- Existing post kickers renumbered §01→§02 … §05→§06 (scheme is §01 = newest)

## README
"Divergence from Uber RIBs-iOS" section extended: the view-seam agreement, the structurally-impossible Swift 6 error (with `ribs-ios#43` link), and a link to the post.

## Site (FAQ)
New Q&A — *"Does napkin hit the Swift 6 '…nonisolated protocol requirement' error?"* — in both the visible body and the `FAQPage` JSON-LD (now 17 questions; JSON validated). High AI/SEO-discoverability value (this is the `feat/discoverability` lineage).

## Docs
- `CrossIsolationPatterns.md`: new section *"Why the view-facing seam is sound under Swift 6"* connecting Patterns 3 & 4 to the isolation reasoning, cross-linked to `ProtocolCompositionOverInheritance`.
- `Presenter.swift`: `Presentable` doc comment now states the Swift 6 conformance soundness + `<doc:CrossIsolationPatterns>` link. **Doc-comment only — no API or behavior change.**

Validated locally: post HTML tag-balanced (24/24 `<p>`, 6/6 `<h2>`, 5/5 `<figure>`) and structurally on par with sibling posts; `feed.xml` / `sitemap.xml` well-formed; FAQ JSON-LD parses; feed/sitemap/index post counts aligned at 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)