### PR TITLE
Launch napkin: scaffold LaunchComponent (root composition), drop LaunchDependency stub

### DIFF
--- a/Tools/napkin/Launch napkin.xctemplate/Default/LaunchComponent.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/Default/LaunchComponent.swift
@@ -1,0 +1,32 @@
+//___FILEHEADER___
+
+import napkin
+
+/// The root composition component for the napkin tree.
+///
+/// `LaunchComponent` terminates the dependency graph — it has no parent
+/// (`Component<EmptyDependency>`) — and is where the app's root services
+/// are constructed. It conforms to `___VARIABLE_productName___Dependency`
+/// so the launch napkin, and transitively every child napkin, can read
+/// those services through the dependency tree.
+///
+/// Instantiate it once at app launch and hand it to the builder:
+///
+///     let builder = ___VARIABLE_productName___Builder(dependency: LaunchComponent())
+///     let router = await builder.build(withListener: appListener)
+///
+/// `nonisolated` because `Component` is dependency-injection plumbing that
+/// runs off any actor. Without it, a module whose **Default Actor
+/// Isolation** build setting is `MainActor` (the Xcode 26 default) fails
+/// to compile this subclass against napkin's `nonisolated` base.
+nonisolated final class LaunchComponent: Component<EmptyDependency>, ___VARIABLE_productName___Dependency, @unchecked Sendable {
+
+    // TODO: Declare the root services this app provides to the napkin tree.
+    // let networkingService: NetworkingServicing
+
+    init() {
+        // TODO: Initialize the root services declared above.
+        // networkingService = NetworkingService()
+        super.init(dependency: EmptyComponent())
+    }
+}

--- a/Tools/napkin/Launch napkin.xctemplate/Default/LaunchDependency.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/Default/LaunchDependency.swift
@@ -1,7 +1,0 @@
-//___FILEHEADER___
-
-import napkin
-
-final class LaunchDependency: ___VARIABLE_productName___Dependency {
-
-}

--- a/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/LaunchComponent.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/LaunchComponent.swift
@@ -1,0 +1,32 @@
+//___FILEHEADER___
+
+import napkin
+
+/// The root composition component for the napkin tree.
+///
+/// `LaunchComponent` terminates the dependency graph — it has no parent
+/// (`Component<EmptyDependency>`) — and is where the app's root services
+/// are constructed. It conforms to `___VARIABLE_productName___Dependency`
+/// so the launch napkin, and transitively every child napkin, can read
+/// those services through the dependency tree.
+///
+/// Instantiate it once at app launch and hand it to the builder:
+///
+///     let builder = ___VARIABLE_productName___Builder(dependency: LaunchComponent())
+///     let router = await builder.build(withListener: appListener)
+///
+/// `nonisolated` because `Component` is dependency-injection plumbing that
+/// runs off any actor. Without it, a module whose **Default Actor
+/// Isolation** build setting is `MainActor` (the Xcode 26 default) fails
+/// to compile this subclass against napkin's `nonisolated` base.
+nonisolated final class LaunchComponent: Component<EmptyDependency>, ___VARIABLE_productName___Dependency, @unchecked Sendable {
+
+    // TODO: Declare the root services this app provides to the napkin tree.
+    // let networkingService: NetworkingServicing
+
+    init() {
+        // TODO: Initialize the root services declared above.
+        // networkingService = NetworkingService()
+        super.init(dependency: EmptyComponent())
+    }
+}

--- a/Tools/napkin/Launch napkin.xctemplate/ownsView/LaunchComponent.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsView/LaunchComponent.swift
@@ -1,0 +1,32 @@
+//___FILEHEADER___
+
+import napkin
+
+/// The root composition component for the napkin tree.
+///
+/// `LaunchComponent` terminates the dependency graph — it has no parent
+/// (`Component<EmptyDependency>`) — and is where the app's root services
+/// are constructed. It conforms to `___VARIABLE_productName___Dependency`
+/// so the launch napkin, and transitively every child napkin, can read
+/// those services through the dependency tree.
+///
+/// Instantiate it once at app launch and hand it to the builder:
+///
+///     let builder = ___VARIABLE_productName___Builder(dependency: LaunchComponent())
+///     let router = await builder.build(withListener: appListener)
+///
+/// `nonisolated` because `Component` is dependency-injection plumbing that
+/// runs off any actor. Without it, a module whose **Default Actor
+/// Isolation** build setting is `MainActor` (the Xcode 26 default) fails
+/// to compile this subclass against napkin's `nonisolated` base.
+nonisolated final class LaunchComponent: Component<EmptyDependency>, ___VARIABLE_productName___Dependency, @unchecked Sendable {
+
+    // TODO: Declare the root services this app provides to the napkin tree.
+    // let networkingService: NetworkingServicing
+
+    init() {
+        // TODO: Initialize the root services declared above.
+        // networkingService = NetworkingService()
+        super.init(dependency: EmptyComponent())
+    }
+}

--- a/Tools/napkin/Launch napkin.xctemplate/ownsView/LaunchDependency.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsView/LaunchDependency.swift
@@ -1,7 +1,0 @@
-//___FILEHEADER___
-
-import napkin
-
-final class LaunchDependency: ___VARIABLE_productName___Dependency {
-
-}


### PR DESCRIPTION
Reported by the maintainer: the Launch napkin is what initializes the root dependency graph, and the template wasn't scaffolding the component that does it.

## The defect
The Launch napkin template emitted an empty `LaunchDependency.swift`:
```swift
final class LaunchDependency: ___VARIABLE_productName___Dependency { }
```
That's a dead stub — the CI-verified example app **doesn't use it**. `RibHouse/SceneDelegate.swift` hand-writes the real root:
```swift
final class AppComponent: Component<EmptyDependency>, LaunchNapkinDependency, @unchecked Sendable {
    let authService: AuthService
    init(authService: AuthService = BarbecueAuthService()) {
        self.authService = authService
        super.init(dependency: EmptyComponent())
    }
}
```
So the template never scaffolded the **root composition component** — the `Component<EmptyDependency>` that terminates the graph and constructs the app's root services. (Git confirms no such file ever existed in this template, so it's a long-standing design gap, not a regression.)

## The fix
Replace `LaunchDependency.swift` → `LaunchComponent.swift` in **all three** Launch variants (`ownsSwiftUIView` previously shipped *no* root-scope file — now consistent):
```swift
nonisolated final class LaunchComponent: Component<EmptyDependency>, ___VARIABLE_productName___Dependency, @unchecked Sendable {
    init() { super.init(dependency: EmptyComponent()) }
}
```
- Modeled on the example app's `AppComponent` and the maintainer's own historical `LaunchComponent` (Scrillionaire, 2021): `Component<EmptyDependency>`, conforms to the napkin's dependency protocol, root services initialized in `init`.
- `nonisolated` is **mandatory** — a bare `Component<EmptyDependency>` subclass reintroduces the exact Xcode 26 `init(dependency:)` isolation error fixed in the previous PR. Carried forward deliberately.
- `TemplateInfo.plist` is option-driven (files by variant directory) — no plist change. No docs referenced the old generated `LaunchDependency`. Reinstalled + verified locally (LaunchComponent in every variant, LaunchDependency gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)