### PR TITLE
README: add "Ask DeepWiki" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FWikipediaBrown%2Fnapkin%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/WikipediaBrown/napkin)
 [![License: Apache 2.0](https://img.shields.io/github/license/WikipediaBrown/napkin?color=blue)](https://github.com/WikipediaBrown/napkin/blob/main/LICENSE.md)
 [![Docs](https://img.shields.io/badge/docs-getnapkin.to-2dbe60)](https://getnapkin.to/documentation/napkin/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/WikipediaBrown/napkin)
 
 napkin is a fork of Uber's [RIBs](https://github.com/uber/ribs-ios) rebuilt on Swift 6.2 native concurrency. It structures iOS and macOS applications as a tree of modular units using the Router-Interactor-Builder pattern, with business logic running off the main actor and routing/presentation pinned to it.
 


### PR DESCRIPTION
DeepWiki finished indexing `WikipediaBrown/napkin`. Before surfacing it, I reviewed the auto-generated wiki via the DeepWiki MCP:

- **Positioning held:** wiki reports RIBs as *"alive, well, and actively maintained … napkin is not a replacement … Clean Architecture on a napkin."* No "RIBs is dead" framing — the careful positioning propagated.
- **iOS 26 rationale:** correctly synthesized as *"deliberate support choice, not the absolute compiler minimum … type-checks down to iOS 18 / macOS 15 (Mutex)."* Minor synthesis artifact (it calls `isolated deinit` the "primary reason … available on iOS 26", slightly overstating causation) — DeepWiki inference, not a repo defect; self-corrects on re-index.
- **Structure** is current and comprehensive (reflects the recent template/docs work, incl. "Swift 6 Concurrency Design Decisions").

Conclusion: safe to badge. Adds an AI-queryable docs entry point next to the existing discoverability surfaces. Canonical badge markdown, placed in the existing badge row after Docs. README-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)