### PR TITLE
404: lead with the interactive napkin on mobile

### DIFF
--- a/Tools/site/404.html
+++ b/Tools/site/404.html
@@ -24,8 +24,13 @@
             gap: var(--s-5);
             align-items: center;
         }
+        /* On phones (single column) the napkin leads; the copy + links
+           follow. DOM order stays copy-first, so screen readers and tab
+           focus still reach the navigation first. */
+        .napkin { order: -1; }
         @media (min-width: 860px) {
             .gone { grid-template-columns: 1fr 1fr; gap: var(--s-7); }
+            .gone__copy, .napkin { order: 0; }   /* side-by-side: copy left, napkin right */
         }
         .gone__title {
             font-family: var(--font-serif);


### PR DESCRIPTION
Follow-up to the interactive 404: on phones the napkin was below the copy + 5-item link list. Now it's the first thing on small screens.

- `.napkin { order: -1 }` in the base (single-column) styles → napkin leads on mobile.
- `@media (min-width: 860px)` resets `.gone__copy, .napkin { order: 0 }` → desktop two-column layout **unchanged** (copy left, napkin right).
- **DOM order untouched** (copy-first) → screen readers and keyboard tab order still hit the navigation links first. Visual prominence for the toy, semantic priority for nav.

Verified in a real browser at both breakpoints:
- Phone 390px: `napTop 105 < copyTop 543` → napkin first ✅
- Desktop 1100px: two 372px columns, copy left / napkin right, screenshot reviewed — no regression ✅
- (Mobile touch draw/wipe already verified on the live deploy in the previous PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)