### PR TITLE
docs: note that `lifecycle` must stay at least internal

### DIFF
--- a/Sources/napkin/Interactor.swift
+++ b/Sources/napkin/Interactor.swift
@@ -147,6 +147,13 @@ public protocol Interactable: Actor, InteractorScope {
     /// The default implementations of ``activate()``, ``deactivate()``,
     /// ``task(priority:_:)``, ``InteractorScope/isActive``, and
     /// ``InteractorScope/isActiveStream`` all forward to this helper.
+    ///
+    /// - Note: This satisfies a `public` protocol requirement, so the declared
+    ///   property must be at least as accessible as the conforming interactor —
+    ///   `internal` for an `internal` type. It cannot be `private` or
+    ///   `fileprivate`. `internal` is the intended visibility: it keeps
+    ///   `lifecycle` out of your module's public API, and you are not meant to
+    ///   call its methods directly.
     nonisolated var lifecycle: InteractorLifecycle { get }
 
     /// Activates the interactor.


### PR DESCRIPTION
## What

Adds a `- Note:` to the `Interactable.lifecycle` requirement explaining that the property must be at least `internal` — it witnesses a `public` protocol requirement, so it cannot be `private`/`fileprivate`.

## Why

Surfaced in use: trying to mark `nonisolated let lifecycle = InteractorLifecycle()` as `private` fails to compile because a witness to a public protocol requirement must be at least as accessible as the conforming type. This documents the constraint on the requirement itself, so it shows up in Xcode quick-help before the compiler error.

## Notes

- Doc-comment only — no behavior change.
- Verified: `swift build` clean; DocC builds with zero warnings; the note renders on the `Interactable/lifecycle` symbol page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)