### PR TITLE
Merge develop into main: document the lifecycle access-control constraint

### DIFF
--- a/Sources/napkin/Interactor.swift
+++ b/Sources/napkin/Interactor.swift
@@ -147,6 +147,13 @@ public protocol Interactable: Actor, InteractorScope {
     /// The default implementations of ``activate()``, ``deactivate()``,
     /// ``task(priority:_:)``, ``InteractorScope/isActive``, and
     /// ``InteractorScope/isActiveStream`` all forward to this helper.
+    ///
+    /// - Note: This satisfies a `public` protocol requirement, so the declared
+    ///   property must be at least as accessible as the conforming interactor —
+    ///   `internal` for an `internal` type. It cannot be `private` or
+    ///   `fileprivate`. `internal` is the intended visibility: it keeps
+    ///   `lifecycle` out of your module's public API, and you are not meant to
+    ///   call its methods directly.
     nonisolated var lifecycle: InteractorLifecycle { get }
 
     /// Activates the interactor.


### PR DESCRIPTION
Promotes the `develop` doc note to `main`.

Carries one change over `main`: a `- Note:` on `Interactable.lifecycle` explaining it must stay at least `internal` (it witnesses a public protocol requirement and cannot be `private`).

Doc-comment only — no behavior change. `swift build` clean; DocC builds with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)