### PR TITLE
templates: normalize pragma marks and refresh comments

### DIFF
--- a/Tools/napkin/Launch napkin.xctemplate/Default/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/Default/___FILEBASENAME___Interactor.swift
@@ -15,6 +15,8 @@ protocol ___VARIABLE_productName___Listener: AnyObject, Sendable {
     // Listener methods are async because the parent's interactor is an actor.
 }
 
+// MARK: - Interactor
+
 final actor ___VARIABLE_productName___Interactor: Interactable {
 
     nonisolated let lifecycle = InteractorLifecycle()
@@ -26,6 +28,8 @@ final actor ___VARIABLE_productName___Interactor: Interactable {
     // in constructor.
     init() {}
 
+    // Called once by the builder, after the router is built, to set the
+    // interactor's weak back-references in a single hop.
     func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
         self.listener = listener

--- a/Tools/napkin/Launch napkin.xctemplate/Default/___FILEBASENAME___Router.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/Default/___FILEBASENAME___Router.swift
@@ -9,6 +9,8 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
     // napkin's ancestor napkins' view.
 }
 
+// MARK: - Router
+
 @MainActor
 final class ___VARIABLE_productName___Router: Router<___VARIABLE_productName___Interactor>, ___VARIABLE_productName___Routing {
 

--- a/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Builder.swift
@@ -27,6 +27,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
     @MainActor
     func build(withListener listener: ___VARIABLE_productName___Listener) async -> ___VARIABLE_productName___Routing {
         let component = ___VARIABLE_productName___Component(dependency: dependency)
+        // `component` resolves this napkin's dependencies; it's unused until you
+        // add some, hence the discard.
         _ = component
         let viewController = ___VARIABLE_productName___ViewController()
         let interactor = ___VARIABLE_productName___Interactor(presenter: viewController)

--- a/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Interactor.swift
@@ -20,6 +20,8 @@ protocol ___VARIABLE_productName___Listener: AnyObject, Sendable {
     // Listener methods are async because the parent's interactor is an actor.
 }
 
+// MARK: - Interactor
+
 final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VARIABLE_productName___PresentableListener {
 
     nonisolated let lifecycle = InteractorLifecycle()
@@ -34,6 +36,8 @@ final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VA
         self.presenter = presenter
     }
 
+    // Called once by the builder, after the router is built, to set the
+    // interactor's weak back-references in a single hop.
     func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
         self.listener = listener

--- a/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Router.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Router.swift
@@ -7,6 +7,8 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
     // TODO: Declare methods the router invokes to manipulate the view hierarchy.
 }
 
+// MARK: - Router
+
 @MainActor
 final class ___VARIABLE_productName___Router:
     LaunchRouter<___VARIABLE_productName___Interactor, ___VARIABLE_productName___ViewControllable>,

--- a/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Builder.swift
@@ -27,6 +27,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
     @MainActor
     func build(withListener listener: ___VARIABLE_productName___Listener) async -> ___VARIABLE_productName___Routing {
         let component = ___VARIABLE_productName___Component(dependency: dependency)
+        // `component` resolves this napkin's dependencies; it's unused until you
+        // add some, hence the discard.
         _ = component
         let viewController = ___VARIABLE_productName___ViewController()
         let interactor = ___VARIABLE_productName___Interactor(presenter: viewController)

--- a/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
@@ -20,6 +20,8 @@ protocol ___VARIABLE_productName___Listener: AnyObject, Sendable {
     // Listener methods are async because the parent's interactor is an actor.
 }
 
+// MARK: - Interactor
+
 final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VARIABLE_productName___PresentableListener {
 
     nonisolated let lifecycle = InteractorLifecycle()
@@ -34,6 +36,8 @@ final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VA
         self.presenter = presenter
     }
 
+    // Called once by the builder, after the router is built, to set the
+    // interactor's weak back-references in a single hop.
     func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
         self.listener = listener

--- a/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Router.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Router.swift
@@ -7,6 +7,8 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
     // TODO: Declare methods the router invokes to manipulate the view hierarchy.
 }
 
+// MARK: - Router
+
 @MainActor
 final class ___VARIABLE_productName___Router:
     LaunchRouter<___VARIABLE_productName___Interactor, ___VARIABLE_productName___ViewControllable>,

--- a/Tools/napkin/napkin.xctemplate/Default/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/napkin.xctemplate/Default/___FILEBASENAME___Interactor.swift
@@ -15,6 +15,8 @@ protocol ___VARIABLE_productName___Listener: AnyObject, Sendable {
     // Listener methods are async because the parent's interactor is an actor.
 }
 
+// MARK: - Interactor
+
 final actor ___VARIABLE_productName___Interactor: Interactable {
 
     nonisolated let lifecycle = InteractorLifecycle()
@@ -26,6 +28,8 @@ final actor ___VARIABLE_productName___Interactor: Interactable {
     // in constructor.
     init() {}
 
+    // Called once by the builder, after the router is built, to set the
+    // interactor's weak back-references in a single hop.
     func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
         self.listener = listener

--- a/Tools/napkin/napkin.xctemplate/Default/___FILEBASENAME___Router.swift
+++ b/Tools/napkin/napkin.xctemplate/Default/___FILEBASENAME___Router.swift
@@ -9,6 +9,8 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
     // napkin's ancestor napkins' view.
 }
 
+// MARK: - Router
+
 @MainActor
 final class ___VARIABLE_productName___Router: Router<___VARIABLE_productName___Interactor>, ___VARIABLE_productName___Routing {
 

--- a/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Builder.swift
@@ -27,6 +27,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
     @MainActor
     func build(withListener listener: ___VARIABLE_productName___Listener) async -> ___VARIABLE_productName___Routing {
         let component = ___VARIABLE_productName___Component(dependency: dependency)
+        // `component` resolves this napkin's dependencies; it's unused until you
+        // add some, hence the discard.
         _ = component
         let viewController = ___VARIABLE_productName___ViewController()
         let interactor = ___VARIABLE_productName___Interactor(presenter: viewController)

--- a/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Interactor.swift
@@ -20,6 +20,8 @@ protocol ___VARIABLE_productName___Listener: AnyObject, Sendable {
     // Listener methods are async because the parent's interactor is an actor.
 }
 
+// MARK: - Interactor
+
 final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VARIABLE_productName___PresentableListener {
 
     nonisolated let lifecycle = InteractorLifecycle()
@@ -34,6 +36,8 @@ final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VA
         self.presenter = presenter
     }
 
+    // Called once by the builder, after the router is built, to set the
+    // interactor's weak back-references in a single hop.
     func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
         self.listener = listener

--- a/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Router.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Router.swift
@@ -7,6 +7,8 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
     // TODO: Declare methods the router invokes to manipulate the view hierarchy.
 }
 
+// MARK: - Router
+
 @MainActor
 final class ___VARIABLE_productName___Router:
     ViewableRouter<___VARIABLE_productName___Interactor, ___VARIABLE_productName___ViewControllable>,

--- a/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Builder.swift
@@ -27,6 +27,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
     @MainActor
     func build(withListener listener: ___VARIABLE_productName___Listener) async -> ___VARIABLE_productName___Routing {
         let component = ___VARIABLE_productName___Component(dependency: dependency)
+        // `component` resolves this napkin's dependencies; it's unused until you
+        // add some, hence the discard.
         _ = component
         let viewController = ___VARIABLE_productName___ViewController()
         let interactor = ___VARIABLE_productName___Interactor(presenter: viewController)

--- a/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
@@ -20,6 +20,8 @@ protocol ___VARIABLE_productName___Listener: AnyObject, Sendable {
     // Listener methods are async because the parent's interactor is an actor.
 }
 
+// MARK: - Interactor
+
 final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VARIABLE_productName___PresentableListener {
 
     nonisolated let lifecycle = InteractorLifecycle()
@@ -34,6 +36,8 @@ final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VA
         self.presenter = presenter
     }
 
+    // Called once by the builder, after the router is built, to set the
+    // interactor's weak back-references in a single hop.
     func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
         self.listener = listener

--- a/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Router.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Router.swift
@@ -7,6 +7,8 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
     // TODO: Declare methods the router invokes to manipulate the view hierarchy.
 }
 
+// MARK: - Router
+
 @MainActor
 final class ___VARIABLE_productName___Router:
     ViewableRouter<___VARIABLE_productName___Interactor, ___VARIABLE_productName___ViewControllable>,


### PR DESCRIPTION
Follow-up to #140 (the `wire()` change). Brings the Xcode templates' structure and comments up to a consistent standard.

- **`// MARK: - Interactor` / `// MARK: - Router`** separators added so every template file marks its main type, mirroring the existing `// MARK: - Builder`. (Interactors had *no* marks; routers were inconsistent — headless had `// MARK: - Private`, owns* had none.)
- Interactors keep the **`// MARK: - Lifecycle`** section from #140.
- **`wire(router:listener:)` documented** — "called once by the builder, after the router is built, to set both weak back-references in one hop."
- The **`_ = component`** discard in the owns-view builders now has an explanatory comment.

Comment/mark only — templates aren't compiled. 16 files, +44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)