### PR TITLE
Merge develop into main: single wire(router:listener:) + template mark/comment cleanup

### DIFF
--- a/Examples/RibHouse/Sources/LaunchNapkin/LaunchNapkinBuilder.swift
+++ b/Examples/RibHouse/Sources/LaunchNapkin/LaunchNapkinBuilder.swift
@@ -33,14 +33,13 @@ final class LaunchNapkinBuilder: Builder<LaunchNapkinDependency>, LaunchNapkinBu
         let loggedInBuilder = LoggedInNapkinBuilder(dependency: component)
         let viewController = LaunchNapkinViewController()
         let interactor = LaunchNapkinInteractor(authService: component.authService)
-        await interactor.set(listener: listener)
         let router = LaunchNapkinRouter(
             interactor: interactor,
             viewController: viewController,
             loggedOutBuilder: loggedOutBuilder,
             loggedInBuilder: loggedInBuilder
         )
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }

--- a/Examples/RibHouse/Sources/LaunchNapkin/LaunchNapkinInteractor.swift
+++ b/Examples/RibHouse/Sources/LaunchNapkin/LaunchNapkinInteractor.swift
@@ -24,8 +24,10 @@ final actor LaunchNapkinInteractor:
         self.authService = authService
     }
 
-    func set(router: LaunchNapkinRouting?) { self.router = router }
-    func set(listener: LaunchNapkinListener?) { self.listener = listener }
+    func wire(router: LaunchNapkinRouting?, listener: LaunchNapkinListener?) {
+        self.router = router
+        self.listener = listener
+    }
 
     func didBecomeActive() async {
         await router?.attachLoggedOut()

--- a/Examples/RibHouse/Sources/LoggedInNapkin/LoggedInNapkinBuilder.swift
+++ b/Examples/RibHouse/Sources/LoggedInNapkin/LoggedInNapkinBuilder.swift
@@ -33,13 +33,12 @@ final class LoggedInNapkinBuilder: Builder<LoggedInNapkinDependency>, LoggedInNa
     ) async -> LoggedInNapkinRouting {
         let viewController = LoggedInNapkinViewController(user: user)
         let interactor = LoggedInNapkinInteractor(presenter: viewController, user: user)
-        await interactor.set(listener: listener)
         let router = LoggedInNapkinRouter(
             interactor: interactor,
             viewController: viewController,
             user: user
         )
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }

--- a/Examples/RibHouse/Sources/LoggedInNapkin/LoggedInNapkinInteractor.swift
+++ b/Examples/RibHouse/Sources/LoggedInNapkin/LoggedInNapkinInteractor.swift
@@ -25,8 +25,10 @@ final actor LoggedInNapkinInteractor: PresentableInteractable, LoggedInNapkinPre
         self.user = user
     }
 
-    func set(router: LoggedInNapkinRouting?) { self.router = router }
-    func set(listener: LoggedInNapkinListener?) { self.listener = listener }
+    func wire(router: LoggedInNapkinRouting?, listener: LoggedInNapkinListener?) {
+        self.router = router
+        self.listener = listener
+    }
 
     func didBecomeActive() async {
         let presenter = self.presenter

--- a/Examples/RibHouse/Sources/LoggedOutNapkin/LoggedOutNapkinBuilder.swift
+++ b/Examples/RibHouse/Sources/LoggedOutNapkin/LoggedOutNapkinBuilder.swift
@@ -18,9 +18,8 @@ final class LoggedOutNapkinBuilder: Builder<LoggedOutNapkinDependency>, LoggedOu
     func build(withListener listener: LoggedOutNapkinListener) async -> LoggedOutNapkinRouting {
         let viewController = LoggedOutNapkinViewController()
         let interactor = LoggedOutNapkinInteractor(presenter: viewController)
-        await interactor.set(listener: listener)
         let router = LoggedOutNapkinRouter(interactor: interactor, viewController: viewController)
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }

--- a/Examples/RibHouse/Sources/LoggedOutNapkin/LoggedOutNapkinInteractor.swift
+++ b/Examples/RibHouse/Sources/LoggedOutNapkin/LoggedOutNapkinInteractor.swift
@@ -23,8 +23,10 @@ final actor LoggedOutNapkinInteractor: PresentableInteractable, LoggedOutNapkinP
         self.presenter = presenter
     }
 
-    func set(router: LoggedOutNapkinRouting?) { self.router = router }
-    func set(listener: LoggedOutNapkinListener?) { self.listener = listener }
+    func wire(router: LoggedOutNapkinRouting?, listener: LoggedOutNapkinListener?) {
+        self.router = router
+        self.listener = listener
+    }
 
     func didBecomeActive() async {
         let presenter = self.presenter

--- a/README.md
+++ b/README.md
@@ -147,9 +147,8 @@ nonisolated final class HomeBuilder: Builder<HomeDependency>, HomeBuildable {
             presenter: viewController,
             userService: component.userService
         )
-        await interactor.set(listener: listener)
         let router = HomeRouter(interactor: interactor, viewController: viewController)
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }
@@ -247,8 +246,10 @@ final actor HomeInteractor: PresentableInteractable, HomePresentableListener {
         self.userService = userService
     }
 
-    func set(router: HomeRouting?) { self.router = router }
-    func set(listener: HomeListener?) { self.listener = listener }
+    func wire(router: HomeRouting?, listener: HomeListener?) {
+        self.router = router
+        self.listener = listener
+    }
 
     func didBecomeActive() async {
         // Lifecycle-bound subscription: cancelled automatically on willResignActive.
@@ -589,9 +590,8 @@ func build(withListener listener: HomeListener) async -> HomeRouting {
     let viewController = HomeViewController()
     let interactor = HomeInteractor(presenter: viewController,
                                     userService: component.userService)
-    await interactor.set(listener: listener)
     let router = HomeRouter(interactor: interactor, viewController: viewController)
-    await interactor.set(router: router)
+    await interactor.wire(router: router, listener: listener)
     return router
 }
 ```
@@ -634,7 +634,7 @@ struct HomeInteractorTests {
         let listener = MockHomeListener()
         let presenter = await MockHomePresentable()
         let interactor = HomeInteractor(presenter: presenter, userService: MockUserService())
-        await interactor.set(listener: listener)
+        await interactor.wire(router: nil, listener: listener)
         await interactor.activate()
 
         await interactor.didTapLogout()

--- a/Snippets/DefiningAFeature/CounterBuilder.swift
+++ b/Snippets/DefiningAFeature/CounterBuilder.swift
@@ -29,14 +29,17 @@ protocol CounterRouting: ViewableRouting, Sendable {
 final actor CounterInteractor: PresentableInteractable, CounterPresentableListener {
     nonisolated let lifecycle = InteractorLifecycle()
     nonisolated let presenter: CounterPresentable
+    weak var router: CounterRouting?
     weak var listener: CounterListener?
 
     init(presenter: CounterPresentable) {
         self.presenter = presenter
     }
 
-    func set(router: CounterRouting?) {}
-    func set(listener: CounterListener?) { self.listener = listener }
+    func wire(router: CounterRouting?, listener: CounterListener?) {
+        self.router = router
+        self.listener = listener
+    }
     func didTapIncrement() async {}
     func didTapDecrement() async {}
     func didTapDone() async {}
@@ -104,9 +107,8 @@ final class CounterBuilder:
         _ = component
         let viewController = CounterViewController()
         let interactor = CounterInteractor(presenter: viewController)
-        await interactor.set(listener: listener)
         let router = CounterRouter(interactor: interactor, viewController: viewController)
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }

--- a/Snippets/DefiningAFeature/CounterInteractor.swift
+++ b/Snippets/DefiningAFeature/CounterInteractor.swift
@@ -38,8 +38,10 @@ final actor CounterInteractor: PresentableInteractable, CounterPresentableListen
         self.presenter = presenter
     }
 
-    func set(router: CounterRouting?) { self.router = router }
-    func set(listener: CounterListener?) { self.listener = listener }
+    func wire(router: CounterRouting?, listener: CounterListener?) {
+        self.router = router
+        self.listener = listener
+    }
 
     func didBecomeActive() async {
         let presenter = self.presenter

--- a/Sources/napkin/napkin.docc/Articles/DefiningAFeature.md
+++ b/Sources/napkin/napkin.docc/Articles/DefiningAFeature.md
@@ -16,7 +16,7 @@ The builder is the only entry point a parent napkin sees. It owns the parent-sup
 
 **Why `async @MainActor`.** The builder constructs view controllers, which are `@MainActor`-isolated. It also calls into the interactor (an actor) to wire the listener and the router. Both crossings require `await`, so the build method itself is `async`.
 
-**Why two-phase wiring.** The interactor needs a router, and the router needs the interactor. We construct the interactor first, hand it to the router, then call `await interactor.set(router: router)`. This breaks the cycle without exposing a mutable property to the outside world; only the builder ever calls `set(router:)`.
+**Why two-phase wiring.** The interactor needs a router, and the router needs the interactor. We construct the interactor first, hand it to the router, then call `await interactor.wire(router: router, listener: listener)` to set both back-references in a single hop. This breaks the cycle without exposing mutable properties to the outside world; only the builder ever calls `wire(router:listener:)`.
 
 ## CounterInteractor.swift
 

--- a/Sources/napkin/napkin.docc/Articles/HeadlessNapkins.md
+++ b/Sources/napkin/napkin.docc/Articles/HeadlessNapkins.md
@@ -39,9 +39,8 @@ final class AnalyticsBuilder:
             eventBus: dependency.eventBus,
             analyticsClient: dependency.analyticsClient
         )
-        await interactor.set(listener: listener)
         let router = AnalyticsRouter(interactor: interactor)
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }
@@ -76,8 +75,10 @@ final actor AnalyticsInteractor: Interactable {
         self.analyticsClient = analyticsClient
     }
 
-    func set(router: AnalyticsRouting?) { self.router = router }
-    func set(listener: AnalyticsListener?) { self.listener = listener }
+    func wire(router: AnalyticsRouting?, listener: AnalyticsListener?) {
+        self.router = router
+        self.listener = listener
+    }
 
     func didBecomeActive() async {
         task {

--- a/Sources/napkin/napkin.docc/Articles/MigratingFromV0.md
+++ b/Sources/napkin/napkin.docc/Articles/MigratingFromV0.md
@@ -115,8 +115,10 @@ A typical v0.x file set on the left, the v2.0.0 equivalent on the right. Treat e
                 self.userService = userService
             }
 
-            func set(router: HomeRouting?) { self.router = router }
-            func set(listener: HomeListener?) { self.listener = listener }
+            func wire(router: HomeRouting?, listener: HomeListener?) {
+                self.router = router
+                self.listener = listener
+            }
 
             func didBecomeActive() async {
                 await MainActor.run { presenter.listener = self }
@@ -236,7 +238,7 @@ The `Builder` and `Component` rings are largely the same:
 - ``Component`` is still `Component<DependencyType>` and still uses ``Component/shared(forCallerKey:_:)`` for cached singletons.
 - The dependency-protocol-as-the-public-shape pattern is unchanged.
 
-The only difference: a v2.0.0 builder's `build` method is `@MainActor func build(withListener:) async`. The `async` is needed because building a napkin involves an `await interactor.set(listener:)` call to wire the listener onto the actor.
+The only difference: a v2.0.0 builder's `build` method is `@MainActor func build(withListener:) async`. The `async` is needed because building a napkin involves an `await interactor.wire(router:listener:)` call to wire the router and listener onto the actor.
 
 ## A migration checklist
 

--- a/Sources/napkin/napkin.docc/Articles/TabBarNapkin.md
+++ b/Sources/napkin/napkin.docc/Articles/TabBarNapkin.md
@@ -70,7 +70,6 @@ final class TabBarNapkinBuilder: Builder<TabBarNapkinDependency>, TabBarNapkinBu
 
         let viewController = TabBarNapkinViewController()
         let interactor = TabBarNapkinInteractor()
-        await interactor.set(listener: listener)
         let router = TabBarNapkinRouter(
             interactor: interactor,
             viewController: viewController,
@@ -78,7 +77,7 @@ final class TabBarNapkinBuilder: Builder<TabBarNapkinDependency>, TabBarNapkinBu
             browseBuilder: browseBuilder,
             profileBuilder: profileBuilder
         )
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }

--- a/Sources/napkin/napkin.docc/Articles/TestingANapkin.md
+++ b/Sources/napkin/napkin.docc/Articles/TestingANapkin.md
@@ -75,7 +75,7 @@ final class LoggedOutNapkinInteractorTests: XCTestCase {
         let presenter = MockLoggedOutNapkinPresentable()
         let listener = MockLaunchToLoggedOutListener()
         let sut = LoggedOutNapkinInteractor(presenter: presenter)
-        await sut.set(listener: listener)
+        await sut.wire(router: nil, listener: listener)
 
         // Act
         await sut.didTapLogin()
@@ -158,7 +158,7 @@ final class LaunchNapkinInteractorTests: XCTestCase {
         auth.loginResult = .success(user)
         let router = MockLaunchNapkinRouting()
         let sut = LaunchNapkinInteractor(authService: auth)
-        await sut.set(router: router)
+        await sut.wire(router: router, listener: nil)
 
         // Act
         await sut.loggedOutDidTapLogin()
@@ -176,7 +176,7 @@ final class LaunchNapkinInteractorTests: XCTestCase {
         auth.loginResult = .failure(MockError.unauthorized)
         let router = MockLaunchNapkinRouting()
         let sut = LaunchNapkinInteractor(authService: auth)
-        await sut.set(router: router)
+        await sut.wire(router: router, listener: nil)
 
         // Act
         await sut.loggedOutDidTapLogin()
@@ -205,7 +205,7 @@ final class LaunchNapkinInteractor_LifecycleTests: XCTestCase {
         let auth = MockAuthService()
         let router = MockLaunchNapkinRouting()
         let sut = LaunchNapkinInteractor(authService: auth)
-        await sut.set(router: router)
+        await sut.wire(router: router, listener: nil)
 
         await sut.didBecomeActive()
 

--- a/Sources/napkin/napkin.docc/Articles/TutorialBuildingALoginFlow.md
+++ b/Sources/napkin/napkin.docc/Articles/TutorialBuildingALoginFlow.md
@@ -134,14 +134,13 @@ final class LaunchNapkinBuilder: Builder<LaunchNapkinDependency>, LaunchNapkinBu
         let loggedInBuilder = LoggedInNapkinBuilder(dependency: component)
         let viewController = LaunchNapkinViewController()
         let interactor = LaunchNapkinInteractor(authService: component.authService)
-        await interactor.set(listener: listener)
         let router = LaunchNapkinRouter(
             interactor: interactor,
             viewController: viewController,
             loggedOutBuilder: loggedOutBuilder,
             loggedInBuilder: loggedInBuilder
         )
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }
@@ -314,9 +313,8 @@ final class LoggedOutNapkinBuilder: Builder<LoggedOutNapkinDependency>, LoggedOu
     func build(withListener listener: LoggedOutNapkinListener) async -> LoggedOutNapkinRouting {
         let viewController = LoggedOutNapkinViewController()
         let interactor = LoggedOutNapkinInteractor(presenter: viewController)
-        await interactor.set(listener: listener)
         let router = LoggedOutNapkinRouter(interactor: interactor, viewController: viewController)
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }
@@ -423,13 +421,12 @@ final class LoggedInNapkinBuilder: ... {
     ) async -> LoggedInNapkinRouting {
         let viewController = LoggedInNapkinViewController(user: user)
         let interactor = LoggedInNapkinInteractor(presenter: viewController, user: user)
-        await interactor.set(listener: listener)
         let router = LoggedInNapkinRouter(
             interactor: interactor,
             viewController: viewController,
             user: user
         )
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }

--- a/Tools/napkin/Launch napkin.xctemplate/Default/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/Default/___FILEBASENAME___Builder.swift
@@ -35,9 +35,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
     func build(withListener listener: ___VARIABLE_productName___Listener) async -> ___VARIABLE_productName___Routing {
         let component = ___VARIABLE_productName___Component(dependency: dependency)
         let interactor = ___VARIABLE_productName___Interactor()
-        await interactor.set(listener: listener)
         let router = ___VARIABLE_productName___Router(interactor: interactor, viewController: component.___VARIABLE_productName___ViewController)
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }

--- a/Tools/napkin/Launch napkin.xctemplate/Default/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/Default/___FILEBASENAME___Interactor.swift
@@ -26,13 +26,12 @@ final actor ___VARIABLE_productName___Interactor: Interactable {
     // in constructor.
     init() {}
 
-    func set(router: ___VARIABLE_productName___Routing?) {
+    func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
-    }
-
-    func set(listener: ___VARIABLE_productName___Listener?) {
         self.listener = listener
     }
+
+    // MARK: - Lifecycle
 
     func didBecomeActive() async {
         // TODO: Implement business logic here.

--- a/Tools/napkin/Launch napkin.xctemplate/Default/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/Default/___FILEBASENAME___Interactor.swift
@@ -15,6 +15,8 @@ protocol ___VARIABLE_productName___Listener: AnyObject, Sendable {
     // Listener methods are async because the parent's interactor is an actor.
 }
 
+// MARK: - Interactor
+
 final actor ___VARIABLE_productName___Interactor: Interactable {
 
     nonisolated let lifecycle = InteractorLifecycle()
@@ -26,6 +28,8 @@ final actor ___VARIABLE_productName___Interactor: Interactable {
     // in constructor.
     init() {}
 
+    // Called once by the builder, after the router is built, to set the
+    // interactor's weak back-references in a single hop.
     func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
         self.listener = listener

--- a/Tools/napkin/Launch napkin.xctemplate/Default/___FILEBASENAME___Router.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/Default/___FILEBASENAME___Router.swift
@@ -9,6 +9,8 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
     // napkin's ancestor napkins' view.
 }
 
+// MARK: - Router
+
 @MainActor
 final class ___VARIABLE_productName___Router: Router<___VARIABLE_productName___Interactor>, ___VARIABLE_productName___Routing {
 

--- a/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Builder.swift
@@ -27,6 +27,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
     @MainActor
     func build(withListener listener: ___VARIABLE_productName___Listener) async -> ___VARIABLE_productName___Routing {
         let component = ___VARIABLE_productName___Component(dependency: dependency)
+        // `component` resolves this napkin's dependencies; it's unused until you
+        // add some, hence the discard.
         _ = component
         let viewController = ___VARIABLE_productName___ViewController()
         let interactor = ___VARIABLE_productName___Interactor(presenter: viewController)

--- a/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Builder.swift
@@ -30,9 +30,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
         _ = component
         let viewController = ___VARIABLE_productName___ViewController()
         let interactor = ___VARIABLE_productName___Interactor(presenter: viewController)
-        await interactor.set(listener: listener)
         let router = ___VARIABLE_productName___Router(interactor: interactor, viewController: viewController)
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }

--- a/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Interactor.swift
@@ -34,13 +34,12 @@ final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VA
         self.presenter = presenter
     }
 
-    func set(router: ___VARIABLE_productName___Routing?) {
+    func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
-    }
-
-    func set(listener: ___VARIABLE_productName___Listener?) {
         self.listener = listener
     }
+
+    // MARK: - Lifecycle
 
     func didBecomeActive() async {
         // TODO: Implement business logic here.

--- a/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Interactor.swift
@@ -20,6 +20,8 @@ protocol ___VARIABLE_productName___Listener: AnyObject, Sendable {
     // Listener methods are async because the parent's interactor is an actor.
 }
 
+// MARK: - Interactor
+
 final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VARIABLE_productName___PresentableListener {
 
     nonisolated let lifecycle = InteractorLifecycle()
@@ -34,6 +36,8 @@ final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VA
         self.presenter = presenter
     }
 
+    // Called once by the builder, after the router is built, to set the
+    // interactor's weak back-references in a single hop.
     func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
         self.listener = listener

--- a/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Router.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Router.swift
@@ -7,6 +7,8 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
     // TODO: Declare methods the router invokes to manipulate the view hierarchy.
 }
 
+// MARK: - Router
+
 @MainActor
 final class ___VARIABLE_productName___Router:
     LaunchRouter<___VARIABLE_productName___Interactor, ___VARIABLE_productName___ViewControllable>,

--- a/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Builder.swift
@@ -27,6 +27,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
     @MainActor
     func build(withListener listener: ___VARIABLE_productName___Listener) async -> ___VARIABLE_productName___Routing {
         let component = ___VARIABLE_productName___Component(dependency: dependency)
+        // `component` resolves this napkin's dependencies; it's unused until you
+        // add some, hence the discard.
         _ = component
         let viewController = ___VARIABLE_productName___ViewController()
         let interactor = ___VARIABLE_productName___Interactor(presenter: viewController)

--- a/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Builder.swift
@@ -30,9 +30,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
         _ = component
         let viewController = ___VARIABLE_productName___ViewController()
         let interactor = ___VARIABLE_productName___Interactor(presenter: viewController)
-        await interactor.set(listener: listener)
         let router = ___VARIABLE_productName___Router(interactor: interactor, viewController: viewController)
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }

--- a/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
@@ -34,13 +34,12 @@ final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VA
         self.presenter = presenter
     }
 
-    func set(router: ___VARIABLE_productName___Routing?) {
+    func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
-    }
-
-    func set(listener: ___VARIABLE_productName___Listener?) {
         self.listener = listener
     }
+
+    // MARK: - Lifecycle
 
     func didBecomeActive() async {
         // TODO: Implement business logic here.

--- a/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
@@ -20,6 +20,8 @@ protocol ___VARIABLE_productName___Listener: AnyObject, Sendable {
     // Listener methods are async because the parent's interactor is an actor.
 }
 
+// MARK: - Interactor
+
 final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VARIABLE_productName___PresentableListener {
 
     nonisolated let lifecycle = InteractorLifecycle()
@@ -34,6 +36,8 @@ final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VA
         self.presenter = presenter
     }
 
+    // Called once by the builder, after the router is built, to set the
+    // interactor's weak back-references in a single hop.
     func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
         self.listener = listener

--- a/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Router.swift
+++ b/Tools/napkin/Launch napkin.xctemplate/ownsView/___FILEBASENAME___Router.swift
@@ -7,6 +7,8 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
     // TODO: Declare methods the router invokes to manipulate the view hierarchy.
 }
 
+// MARK: - Router
+
 @MainActor
 final class ___VARIABLE_productName___Router:
     LaunchRouter<___VARIABLE_productName___Interactor, ___VARIABLE_productName___ViewControllable>,

--- a/Tools/napkin/napkin.xctemplate/Default/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/napkin.xctemplate/Default/___FILEBASENAME___Builder.swift
@@ -35,9 +35,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
     func build(withListener listener: ___VARIABLE_productName___Listener) async -> ___VARIABLE_productName___Routing {
         let component = ___VARIABLE_productName___Component(dependency: dependency)
         let interactor = ___VARIABLE_productName___Interactor()
-        await interactor.set(listener: listener)
         let router = ___VARIABLE_productName___Router(interactor: interactor, viewController: component.___VARIABLE_productName___ViewController)
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }

--- a/Tools/napkin/napkin.xctemplate/Default/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/napkin.xctemplate/Default/___FILEBASENAME___Interactor.swift
@@ -26,13 +26,12 @@ final actor ___VARIABLE_productName___Interactor: Interactable {
     // in constructor.
     init() {}
 
-    func set(router: ___VARIABLE_productName___Routing?) {
+    func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
-    }
-
-    func set(listener: ___VARIABLE_productName___Listener?) {
         self.listener = listener
     }
+
+    // MARK: - Lifecycle
 
     func didBecomeActive() async {
         // TODO: Implement business logic here.

--- a/Tools/napkin/napkin.xctemplate/Default/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/napkin.xctemplate/Default/___FILEBASENAME___Interactor.swift
@@ -15,6 +15,8 @@ protocol ___VARIABLE_productName___Listener: AnyObject, Sendable {
     // Listener methods are async because the parent's interactor is an actor.
 }
 
+// MARK: - Interactor
+
 final actor ___VARIABLE_productName___Interactor: Interactable {
 
     nonisolated let lifecycle = InteractorLifecycle()
@@ -26,6 +28,8 @@ final actor ___VARIABLE_productName___Interactor: Interactable {
     // in constructor.
     init() {}
 
+    // Called once by the builder, after the router is built, to set the
+    // interactor's weak back-references in a single hop.
     func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
         self.listener = listener

--- a/Tools/napkin/napkin.xctemplate/Default/___FILEBASENAME___Router.swift
+++ b/Tools/napkin/napkin.xctemplate/Default/___FILEBASENAME___Router.swift
@@ -9,6 +9,8 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
     // napkin's ancestor napkins' view.
 }
 
+// MARK: - Router
+
 @MainActor
 final class ___VARIABLE_productName___Router: Router<___VARIABLE_productName___Interactor>, ___VARIABLE_productName___Routing {
 

--- a/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Builder.swift
@@ -27,6 +27,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
     @MainActor
     func build(withListener listener: ___VARIABLE_productName___Listener) async -> ___VARIABLE_productName___Routing {
         let component = ___VARIABLE_productName___Component(dependency: dependency)
+        // `component` resolves this napkin's dependencies; it's unused until you
+        // add some, hence the discard.
         _ = component
         let viewController = ___VARIABLE_productName___ViewController()
         let interactor = ___VARIABLE_productName___Interactor(presenter: viewController)

--- a/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Builder.swift
@@ -30,9 +30,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
         _ = component
         let viewController = ___VARIABLE_productName___ViewController()
         let interactor = ___VARIABLE_productName___Interactor(presenter: viewController)
-        await interactor.set(listener: listener)
         let router = ___VARIABLE_productName___Router(interactor: interactor, viewController: viewController)
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }

--- a/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Interactor.swift
@@ -34,13 +34,12 @@ final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VA
         self.presenter = presenter
     }
 
-    func set(router: ___VARIABLE_productName___Routing?) {
+    func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
-    }
-
-    func set(listener: ___VARIABLE_productName___Listener?) {
         self.listener = listener
     }
+
+    // MARK: - Lifecycle
 
     func didBecomeActive() async {
         // TODO: Implement business logic here.

--- a/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Interactor.swift
@@ -20,6 +20,8 @@ protocol ___VARIABLE_productName___Listener: AnyObject, Sendable {
     // Listener methods are async because the parent's interactor is an actor.
 }
 
+// MARK: - Interactor
+
 final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VARIABLE_productName___PresentableListener {
 
     nonisolated let lifecycle = InteractorLifecycle()
@@ -34,6 +36,8 @@ final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VA
         self.presenter = presenter
     }
 
+    // Called once by the builder, after the router is built, to set the
+    // interactor's weak back-references in a single hop.
     func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
         self.listener = listener

--- a/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Router.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsSwiftUIView/___FILEBASENAME___Router.swift
@@ -7,6 +7,8 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
     // TODO: Declare methods the router invokes to manipulate the view hierarchy.
 }
 
+// MARK: - Router
+
 @MainActor
 final class ___VARIABLE_productName___Router:
     ViewableRouter<___VARIABLE_productName___Interactor, ___VARIABLE_productName___ViewControllable>,

--- a/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Builder.swift
@@ -27,6 +27,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
     @MainActor
     func build(withListener listener: ___VARIABLE_productName___Listener) async -> ___VARIABLE_productName___Routing {
         let component = ___VARIABLE_productName___Component(dependency: dependency)
+        // `component` resolves this napkin's dependencies; it's unused until you
+        // add some, hence the discard.
         _ = component
         let viewController = ___VARIABLE_productName___ViewController()
         let interactor = ___VARIABLE_productName___Interactor(presenter: viewController)

--- a/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Builder.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Builder.swift
@@ -30,9 +30,8 @@ nonisolated final class ___VARIABLE_productName___Builder: Builder<___VARIABLE_p
         _ = component
         let viewController = ___VARIABLE_productName___ViewController()
         let interactor = ___VARIABLE_productName___Interactor(presenter: viewController)
-        await interactor.set(listener: listener)
         let router = ___VARIABLE_productName___Router(interactor: interactor, viewController: viewController)
-        await interactor.set(router: router)
+        await interactor.wire(router: router, listener: listener)
         return router
     }
 }

--- a/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
@@ -34,13 +34,12 @@ final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VA
         self.presenter = presenter
     }
 
-    func set(router: ___VARIABLE_productName___Routing?) {
+    func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
-    }
-
-    func set(listener: ___VARIABLE_productName___Listener?) {
         self.listener = listener
     }
+
+    // MARK: - Lifecycle
 
     func didBecomeActive() async {
         // TODO: Implement business logic here.

--- a/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Interactor.swift
@@ -20,6 +20,8 @@ protocol ___VARIABLE_productName___Listener: AnyObject, Sendable {
     // Listener methods are async because the parent's interactor is an actor.
 }
 
+// MARK: - Interactor
+
 final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VARIABLE_productName___PresentableListener {
 
     nonisolated let lifecycle = InteractorLifecycle()
@@ -34,6 +36,8 @@ final actor ___VARIABLE_productName___Interactor: PresentableInteractable, ___VA
         self.presenter = presenter
     }
 
+    // Called once by the builder, after the router is built, to set the
+    // interactor's weak back-references in a single hop.
     func wire(router: ___VARIABLE_productName___Routing?, listener: ___VARIABLE_productName___Listener?) {
         self.router = router
         self.listener = listener

--- a/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Router.swift
+++ b/Tools/napkin/napkin.xctemplate/ownsView/___FILEBASENAME___Router.swift
@@ -7,6 +7,8 @@ protocol ___VARIABLE_productName___ViewControllable: ViewControllable {
     // TODO: Declare methods the router invokes to manipulate the view hierarchy.
 }
 
+// MARK: - Router
+
 @MainActor
 final class ___VARIABLE_productName___Router:
     ViewableRouter<___VARIABLE_productName___Interactor, ___VARIABLE_productName___ViewControllable>,


### PR DESCRIPTION
Promotes two merged PRs from `develop` to `main`:

- **#140** — collapse `set(router:)`/`set(listener:)` into a single `wire(router:listener:)` across the framework (RibHouse example, snippets, all 6 Xcode templates, README + 6 DocC articles incl. prose). Builders now wire both back-references in one actor hop.
- **#141** — normalize template pragma marks (`// MARK: - Interactor` / `// MARK: - Router`) and refresh comments (document `wire()`, explain `_ = component`).

Verified on develop: `swift build` + snippets, DocC (zero warnings), RibHouse app (`xcodebuild` BUILD SUCCEEDED), and `grep` confirms 0 remaining `set(router:)`/`set(listener:)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)