### PR TITLE
fix(install): skip cruft (* 2.*, .DS_Store) when installing templates

### DIFF
--- a/Tools/InstallXcodeTemplates.sh
+++ b/Tools/InstallXcodeTemplates.sh
@@ -37,6 +37,12 @@ xcodeTemplate () {
   cp -R "$SRC/Launch $PROJECT_NAME.xctemplate/ownsView/"* "$XCODE_TEMPLATE_DIR/Launch $PROJECT_NAME.xctemplate/ownsViewwithXIB/"
   cp -R "$SRC/$PROJECT_NAME.xctemplate/ownsView/"* "$XCODE_TEMPLATE_DIR/$PROJECT_NAME.xctemplate/ownsViewwithStoryboard/"
   cp -R "$SRC/Launch $PROJECT_NAME.xctemplate/ownsView/"* "$XCODE_TEMPLATE_DIR/Launch $PROJECT_NAME.xctemplate/ownsViewwithStoryboard/"
+
+  # Strip cruft that can exist in a working copy: macOS metadata and Xcode's
+  # " 2" duplicate files. These are git-ignored (see .gitignore `* 2.*`) so they
+  # never show in `git status`, but `cp -R` would otherwise install them and
+  # Xcode would emit them as duplicate sources (e.g. a stray `LaunchComponent 2`).
+  find "$XCODE_TEMPLATE_DIR" \( -name "* 2.*" -o -name ".DS_Store" \) -delete
 }
 
 xcodeTemplate


### PR DESCRIPTION
## Bug

`InstallXcodeTemplates.sh` copies whole `.xctemplate` directories with `cp -R`, which also picks up **git-ignored cruft** present in a working copy — macOS `.DS_Store` and Xcode's `" 2"` duplicate files (ignored via `.gitignore` `* 2.*`, so they never appear in `git status`). A stray `LaunchComponent 2.swift` got installed, and Xcode then emitted a duplicate `LaunchComponent` for **every** Launch napkin.

## Fix

After copying, strip `* 2.*` and `.DS_Store` from the install dir.

## Verified

Planted `LaunchComponent 2.swift` + `.DS_Store` in the source, reinstalled → **0** cruft files installed, 5 real `LaunchComponent.swift` intact. `bash -n` clean. (The repo itself never tracked the strays; this prevents a dirty working copy from leaking them into a local install.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)