### PR TITLE
Docs: weak-presenter rule everywhere, streaming DocC article, crash-shape fixes

### DIFF
--- a/.claude/skills/run-ribhouse/SKILL.md
+++ b/.claude/skills/run-ribhouse/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: run-ribhouse
+description: Use when asked to run, launch, demo, or visually verify the RibHouse example app (Examples/RibHouse) on the iOS simulator — including capturing screenshots or checking live streaming behavior (pit summary, Pit Board, last-call banner).
+---
+
+# Running RibHouse on the iOS Simulator
+
+`xcodebuild … test` works headlessly, but SEEING the app needs `simctl` + the Simulator app. `simctl` cannot tap — drive interactions with the UI tests.
+
+## Launch and screenshot
+
+```bash
+UDID=$(xcrun simctl list devices available | grep -E '^\s+iPhone 17 \(' | head -1 | grep -oE '[A-F0-9-]{36}')
+xcrun simctl boot "$UDID" 2>/dev/null; open -a Simulator
+cd Examples/RibHouse
+xcodebuild -project RibHouse.xcodeproj -scheme RibHouse \
+  -destination "platform=iOS Simulator,id=$UDID" -derivedDataPath /tmp/rhdd build
+xcrun simctl install "$UDID" /tmp/rhdd/Build/Products/Debug-iphonesimulator/RibHouse.app
+xcrun simctl launch "$UDID" com.napkin.example.RibHouse -fastTicks
+sleep 3 && xcrun simctl io "$UDID" screenshot /tmp/rh-launch.png
+```
+
+- `-fastTicks` shrinks the PitService/SpecialsService intervals (0.5s / 0.75s) so streaming is visible within seconds. Omit it for the real cadence (4s / 6s).
+- LOOK at the screenshot (Read tool). Expected at launch: cream "Step inside the smokehouse" LoggedOut screen. A blank frame means the launch failed.
+
+## Driving interactions (login → Pit Board → logout)
+
+There is no `simctl` tap. Drive the real UI with the XCUITests while a parallel loop screenshots the simulator:
+
+```bash
+for i in $(seq -w 1 60); do xcrun simctl io "$UDID" screenshot /tmp/drive-$i.png; sleep 1.5; done &
+xcodebuild -project RibHouse.xcodeproj -scheme RibHouse \
+  -destination "platform=iOS Simulator,id=$UDID" \
+  -only-testing:RibHouseUITests/RibHouseUITests/testLoginRevealsBarbecueFoodsAndLogoutReturns test
+```
+
+Frame sizes hint at content when picking which to Read: cream LoggedOut ≈158KB; dark LoggedIn/PitBoard ≈195–250KB; multi-MB frames are mid-transition blends (often the best evidence that streams are animating).
+
+## Gotchas
+
+- New Swift files or newly recorded snapshot PNGs are invisible to the tracked `.xcodeproj` until `xcodegen` runs from `Examples/RibHouse/` — the generated project is an explicit file list.
+- The test harness reinstalls and relaunches the app itself; args from a manual `simctl launch` don't apply to test-driven runs (the fastTicks UI test passes its own launch argument).
+- Full suite command lives in AGENTS.md: `xcodebuild … -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" test`.

--- a/.gitignore
+++ b/.gitignore
@@ -112,7 +112,8 @@ docs/napkin-icon@2x.png
 Package.resolved
 
 # Claude Code session metadata
-.claude/
+.claude/*
+!.claude/skills/
 
 # iCloud Drive sync duplicates (working in an iCloud-synced directory
 # creates "filename 2.ext" / "filename 3.ext" siblings on conflict).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,8 +305,9 @@ For each feature:
 6. Mark listener and presentable protocol methods `async`. Conform listener
    protocols to `Sendable`.
 7. SwiftUI views: replace `@ObservedObject var viewModel: HomeViewModel` with
-   `@Bindable var presenter: HomePresenter`. Replace event handlers with
-   `dispatch { await listener?.didTapX() }`.
+   `weak var presenter: HomePresenter?`, reading its properties directly and
+   rebinding with `@Bindable` inside `body` only when a two-way binding is
+   needed. Replace event handlers with `dispatch { await listener?.didTapX() }`.
 8. `Builder.build(...)` becomes `async @MainActor` when it constructs a view
    controller.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,8 +249,9 @@ re-adopt against the new shape.
   `lifecycle: AnyPublisher<RouterLifecycle, Never>` Combine publisher. The
   `RouterLifecycle` enum has been removed.
 - **`Presenter`:** `@MainActor @Observable open class`. Subclasses' stored
-  properties are observable to SwiftUI views via `@Bindable` and to UIKit
-  views via `Observations { presenter.foo }`. The `Presentable` protocol is
+  properties are observable to SwiftUI views directly (rebind with
+  `@Bindable` in `body` for two-way bindings) and to UIKit views via
+  `Observations { presenter.foo }`. The `Presentable` protocol is
   `@MainActor`.
 - **`Component`:** `Synchronization.Mutex` replaces `NSRecursiveLock` for
   shared-instance storage. `Component` and `EmptyComponent` are
@@ -311,7 +312,7 @@ For each feature:
 8. `Builder.build(...)` becomes `async @MainActor` when it constructs a view
    controller.
 
-See `Examples/LaunchNapkinApp` and the rewritten `README.md` for working
+See `Examples/RibHouse` and the rewritten `README.md` for working
 reference code.
 
 ### Divergence from upstream Uber RIBs-iOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,8 +292,14 @@ For each feature:
 3. Drop `override` keyword from `didBecomeActive` / `willResignActive` (they're
    protocol default implementations now, not class overrides). Mark them `async`.
 4. Replace `cancellables` and Combine `.sink { … }` subscriptions with
-   `task { for await … in Observations { … } }` inside `didBecomeActive`. The
-   task is auto-cancelled on `deactivate`.
+   lifecycle-bound tasks inside `didBecomeActive`: `task { for await … in
+   service.stream() { … } }` for service streams, or — for `@Observable`
+   state — `task { @MainActor [weak self] in for await … in
+   Observations({ … }) { … } }`. The observation loop must be bound to the
+   actor that owns the state; iterating `Observations` directly inside the
+   nonisolated `task {}` closure crashes the current Swift 6 compiler
+   ([swiftlang/swift#90370](https://github.com/swiftlang/swift/issues/90370)).
+   Tasks are auto-cancelled on `deactivate`.
 5. Mark routing protocol methods `async`. Remove every `Task { @MainActor in }`
    wrapper from routing method bodies — routers are already `@MainActor`.
 6. Mark listener and presentable protocol methods `async`. Conform listener

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ Data flows down the napkin tree; events flow up through listener protocols. Buil
 | `.catch { presentError(…); return Just(fallback) }` | `do { for try await … } catch { await presenter.presentError(…) }` | Both are terminal — emit a fallback in the `catch` if you need one |
 | `.map` / transforms mid-pipeline | Plain code in the loop body | It's just a `for` loop |
 | `.receive(on: DispatchQueue.main)` | `await presenter.…` | The presenter is `@MainActor`; the crossing is explicit |
-| `assign(to:on:)` / nested `ObservableObject` view model | Set the `@Observable` presenter property; SwiftUI reads via `@Bindable` | The view-model layer disappears |
+| `assign(to:on:)` / nested `ObservableObject` view model | Set the `@Observable` presenter property; SwiftUI reads it directly | The view-model layer disappears |
 | `tapSubject` on the SwiftUI view + `.sink` in the VC | `dispatch { await listener?.didTapX() }` | See [SwiftUI Integration](#swiftui-integration) |
 | `publisher(for: \.keyPath)` (KVO on UIKit objects) | The UIKit override/callback KVO was wrapping + `dispatch {}` | Not every pipe becomes a stream |
 | `combineLatest` / `merge` / `debounce` / `removeDuplicates` | [swift-async-algorithms](https://github.com/apple/swift-async-algorithms) | Official Apple package, not part of the standard library |
@@ -654,7 +654,7 @@ Teardown is a closed loop with no leak path: detaching the napkin cancels the `t
 
 ### From the service to the screen
 
-One value crosses four seams on its way to a pixel: service → interactor (`task { for await }`), interactor → presenter (an `await`ed async method), presenter → view (`@Observable` read via `@Bindable`), and view → interactor (`dispatch {}`). Here a second napkin, deeper in the tree, subscribes to the *same* service — each `userStream()` call is an independent stream, so fan-out just works. Because every stream starts with the current value, a napkin attached after login learns the auth state immediately — an upgrade over the PassthroughSubject original, where late subscribers waited for the next change. It carries the value through the presenter into SwiftUI:
+One value crosses four seams on its way to a pixel: service → interactor (`task { for await }`), interactor → presenter (an `await`ed async method), presenter → view (a direct `@Observable` read), and view → interactor (`dispatch {}`). Here a second napkin, deeper in the tree, subscribes to the *same* service — each `userStream()` call is an independent stream, so fan-out just works. Because every stream starts with the current value, a napkin attached after login learns the auth state immediately — an upgrade over the PassthroughSubject original, where late subscribers waited for the next change. It carries the value through the presenter into SwiftUI:
 
 <details>
 <summary>The 0.x version this replaces</summary>
@@ -744,7 +744,7 @@ struct ProfileView: View {
 Three notes from real migrations:
 
 - **Many subjects collapse into one presenter.** Parallel subjects (`institutions`, `rank`, `user`) become stored properties on a single presenter — several pipes become several properties, not several streams. Collections included: `var institutions: [Institution]` drives `ForEach` directly, and per-subview view-model construction disappears (child views take presenter properties as plain values).
-- **Formatting moves into the presenter.** 0.x ran `compactMap { currencyFormatter.string(from:) }` inside view-controller pipelines; that transform belongs in the presenter method — which is the `Presenter` class's stated job. Where the hosting controller also feeds UIKit chrome (a navigation title, a bar-button label), the same presenter serves both: `@Bindable` for SwiftUI, `Observations {}` for UIKit — see [the SwiftUI Integration guide](https://getnapkin.to/documentation/napkin/swiftuiintegration).
+- **Formatting moves into the presenter.** 0.x ran `compactMap { currencyFormatter.string(from:) }` inside view-controller pipelines; that transform belongs in the presenter method — which is the `Presenter` class's stated job. Where the hosting controller also feeds UIKit chrome (a navigation title, a bar-button label), the same presenter serves both: a direct read for SwiftUI, `Observations {}` for UIKit — see [the SwiftUI Integration guide](https://getnapkin.to/documentation/napkin/swiftuiintegration).
 - **Animations.** `.transition` / `.animation(value:)` on the view keep working. Where 0.x relied on implicit animation from `objectWillChange`, wrap the mutation in `withAnimation` inside the presenter method — it's `@MainActor`, so this is legal and local.
 
 ### Events: replacing PassthroughSubject

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ For detaching, the order is reversed: dismiss the view, then `await detachChild(
 
 ### Presenter (Optional)
 
-The **Presenter** transforms business data into view-friendly formats. It sits between the interactor and the view controller. `Presenter` is `@MainActor` and `@Observable`, so SwiftUI views can read its stored properties directly via `@Bindable`. Re-annotate subclasses with `@Observable` so their own stored properties are tracked too:
+The **Presenter** transforms business data into view-friendly formats. It sits between the interactor and the view controller. `Presenter` is `@MainActor` and `@Observable`, so SwiftUI views can read its stored properties directly. Re-annotate subclasses with `@Observable` so their own stored properties are tracked too:
 
 ```swift
 protocol HomePresentable: Presentable, Sendable {

--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@ final actor ProfileInteractor: PresentableInteractable {
 }
 ```
 
-The presenter *is* the view model. Its `@Observable` stored property replaces the subject, the `assign`, the nested `ObservableObject`, and the `receive(on: main)` — SwiftUI reads it directly: Hold it weakly — the presenter owns the view controller that owns the view; rebind with `@Bindable` inside `body` when you need two-way bindings.
+The presenter *is* the view model. Its `@Observable` stored property replaces the subject, the `assign`, the nested `ObservableObject`, and the `receive(on: main)` — SwiftUI reads it directly. Hold the presenter weakly (it owns the view controller that owns the view), and rebind with `@Bindable` inside `body` when you need two-way bindings:
 
 ```swift
 @MainActor
@@ -1022,7 +1022,7 @@ protocol HomePresentableListener: AnyObject, Sendable {
 }
 
 struct HomeView: View {
-    @Bindable var presenter: HomePresenter
+    weak var presenter: HomePresenter?
     weak var listener: HomePresentableListener?
 
     var body: some View {

--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@ final actor ProfileInteractor: PresentableInteractable {
 }
 ```
 
-The presenter *is* the view model. Its `@Observable` stored property replaces the subject, the `assign`, the nested `ObservableObject`, and the `receive(on: main)` — SwiftUI reads it directly:
+The presenter *is* the view model. Its `@Observable` stored property replaces the subject, the `assign`, the nested `ObservableObject`, and the `receive(on: main)` — SwiftUI reads it directly: Hold it weakly — the presenter owns the view controller that owns the view; rebind with `@Bindable` inside `body` when you need two-way bindings.
 
 ```swift
 @MainActor
@@ -728,10 +728,13 @@ final class ProfilePresenter: Presenter<ProfileViewController>, ProfilePresentab
 }
 
 struct ProfileView: View {
-    @Bindable var presenter: ProfilePresenter
+    // Weak: the presenter owns the view controller, which owns this view —
+    // a strong reference here would be a retain cycle. The interactor keeps
+    // the presenter alive for the napkin's whole attached lifetime.
+    weak var presenter: ProfilePresenter?
 
     var body: some View {
-        Text(presenter.greeting)
+        Text(presenter?.greeting ?? "")
     }
 }
 ```
@@ -1009,7 +1012,7 @@ func build(withListener listener: HomeListener) async -> HomeRouting {
 
 (To render formatted state, give the interactor a `nonisolated let presenter` and call `await presenter.presentUser(...)` — the separate `@Observable` `Presenter` shown in [Core Components](#core-components).)
 
-When you *do* want a separate `@Observable` presenter holding formatted view-state, use the `Presenter` base class as shown in [Core Components](#core-components) — it's parameterized over your concrete view-controller type: build the view controller first, hand it to `Presenter`'s initializer, and let the view read the presenter via `@Bindable`. Re-annotate the subclass with `@Observable` so its stored properties are tracked.
+When you *do* want a separate `@Observable` presenter holding formatted view-state, use the `Presenter` base class as shown in [Core Components](#core-components) — it's parameterized over your concrete view-controller type: build the view controller first, hand it to `Presenter`'s initializer, and let the view hold the presenter `weak` and read its properties directly. Re-annotate the subclass with `@Observable` so its stored properties are tracked.
 
 Forward user actions to the interactor with `dispatch { await listener?.didTapX() }`. The `dispatch` helper is `@MainActor` and spawns an unstructured `Task` to call the actor-isolated listener — it's the bridge from a synchronous SwiftUI button handler to the async listener method:
 

--- a/README.md
+++ b/README.md
@@ -891,7 +891,7 @@ final class ProfileViewController: UIViewController {
 
 Tap enums with associated values (`case institution(itemId:institutionId:)`) get the same treatment: they become listener methods with parameters, and the enum-plus-`switch` ceremony deletes.
 
-For operator-heavy pipelines — `combineLatest`, `merge`, `debounce`, `removeDuplicates` — reach for [swift-async-algorithms](https://github.com/apple/swift-async-algorithms), Apple's official package of `AsyncSequence` algorithms. Migration mechanics beyond streaming live in [Migrating from v0](https://getnapkin.to/documentation/napkin/migratingfromv0); lifecycle binding rules in [the lifecycle guide](https://getnapkin.to/documentation/napkin/lifecycle); the `task {}` vs `Task {}` decision rules in [Cross-Isolation Patterns](https://getnapkin.to/documentation/napkin/crossisolationpatterns).
+For operator-heavy pipelines — `combineLatest`, `merge`, `debounce`, `removeDuplicates` — reach for [swift-async-algorithms](https://github.com/apple/swift-async-algorithms), Apple's official package of `AsyncSequence` algorithms. Migration mechanics beyond streaming live in [Migrating from v0](https://getnapkin.to/documentation/napkin/migratingfromv0); lifecycle binding rules in [the lifecycle guide](https://getnapkin.to/documentation/napkin/lifecycle); the `task {}` vs `Task {}` decision rules in [Cross-Isolation Patterns](https://getnapkin.to/documentation/napkin/crossisolationpatterns). This section also lives as a DocC article: [Streaming State Down the Tree](https://getnapkin.to/documentation/napkin/streamingstatedownthetree).
 
 ## Launching the App
 

--- a/Snippets/Streaming/AuthStateStreaming.swift
+++ b/Snippets/Streaming/AuthStateStreaming.swift
@@ -193,9 +193,12 @@ final class ProfilePresenter: Presenter<ProfileViewController>, ProfilePresentab
 }
 
 struct ProfileView: View {
-    @Bindable var presenter: ProfilePresenter
+    // Weak: the presenter owns the view controller, which owns this view —
+    // a strong reference here would be a retain cycle. The interactor keeps
+    // the presenter alive for the napkin's whole attached lifetime.
+    weak var presenter: ProfilePresenter?
 
     var body: some View {
-        Text(presenter.greeting)
+        Text(presenter?.greeting ?? "")
     }
 }

--- a/Sources/napkin/Presenter.swift
+++ b/Sources/napkin/Presenter.swift
@@ -73,6 +73,8 @@ public protocol Presentable: AnyObject {}
 ///   add `@Observable`-friendly stored properties, and have it conform to
 ///   the feature's `Presentable` protocol. The view controller renders
 ///   from the presenter and forwards user events to a listener.
+///   Re-annotate subclasses with `@Observable` so their own stored
+///   properties are tracked.
 /// - **Viewful napkin without a separate presenter.** Have the view
 ///   controller conform to the feature's `Presentable` protocol directly,
 ///   and skip `Presenter`.
@@ -110,14 +112,17 @@ public protocol Presentable: AnyObject {}
 ///
 /// **Read it from SwiftUI:**
 ///
+/// Hold the presenter weakly — it owns the view controller that owns the
+/// view. Rebind with `@Bindable` inside `body` for two-way bindings.
+///
 /// ```swift
 /// struct HomeView: View {
-///     @Bindable var presenter: HomePresenter
+///     weak var presenter: HomePresenter?
 ///     let listener: HomeViewListener
 ///
 ///     var body: some View {
 ///         VStack {
-///             Text(presenter.displayName)
+///             Text(presenter?.displayName ?? "")
 ///             Button("Logout") {
 ///                 dispatch { await listener.didTapLogout() }
 ///             }

--- a/Sources/napkin/Presenter.swift
+++ b/Sources/napkin/Presenter.swift
@@ -31,9 +31,11 @@ import Observation
 /// You have two options for who conforms to a feature-specific `Presentable`:
 ///
 /// - A dedicated ``Presenter`` subclass (recommended when there is non-trivial
-///   view-state to hold). The view controller observes the presenter via
-///   `@Bindable` (SwiftUI) or `Observations { ... }` (UIKit) and stays a
-///   thin renderer.
+///   view-state to hold). The view controller holds the presenter and
+///   SwiftUI reads its stored properties directly (`@Bindable` locally in
+///   `body` for two-way bindings), or UIKit observes them via
+///   `Observations { ... }`; either way the view controller stays a thin
+///   renderer.
 /// - The view controller itself, when there is no separate state to hold and
 ///   the presenter would just delegate every method to the view controller
 ///   anyway.
@@ -58,9 +60,10 @@ public protocol Presentable: AnyObject {}
 
 /// A base class for presenters with `@Observable` view state.
 ///
-/// `Presenter` is `@MainActor`-isolated and `@Observable`, so SwiftUI views
-/// can read its stored properties directly via `@Bindable` and UIKit views
-/// can observe them via the `Observations { ... }` macro.
+/// `Presenter` is `@MainActor`-isolated and `@Observable`. The view
+/// controller holds the presenter and SwiftUI reads its stored properties
+/// directly (`@Bindable` locally in `body` for two-way bindings); UIKit
+/// views can observe them via the `Observations { ... }` macro.
 ///
 /// ## Overview
 ///

--- a/Sources/napkin/napkin.docc/Articles/HeadlessNapkins.md
+++ b/Sources/napkin/napkin.docc/Articles/HeadlessNapkins.md
@@ -82,7 +82,7 @@ final actor AnalyticsInteractor: Interactable {
 
     func didBecomeActive() async {
         task {
-            for await event in self.eventBus.events {
+            for await event in self.eventBus.events() {
                 do {
                     try await self.analyticsClient.send(event)
                 } catch {

--- a/Sources/napkin/napkin.docc/Articles/Lifecycle.md
+++ b/Sources/napkin/napkin.docc/Articles/Lifecycle.md
@@ -40,7 +40,7 @@ Long-lived work — anything that watches an external source — goes in ``Inter
 ```swift
 func didBecomeActive() async {
     task {
-        for await user in userService.userStream {
+        for await user in userService.userStream() {
             await presenter.presentUser(user)
         }
     }

--- a/Sources/napkin/napkin.docc/Articles/MigratingFromV0.md
+++ b/Sources/napkin/napkin.docc/Articles/MigratingFromV0.md
@@ -124,7 +124,7 @@ A typical v0.x file set on the left, the v2.0.0 equivalent on the right. Treat e
                 await MainActor.run { presenter.listener = self }
 
                 task {
-                    for await user in self.userService.userStream {
+                    for await user in self.userService.userStream() {
                         await self.presenter.update(user: user)
                     }
                 }
@@ -221,7 +221,7 @@ A typical v0.x file set on the left, the v2.0.0 equivalent on the right. Treat e
 | (none) | `nonisolated let lifecycle = InteractorLifecycle()` | Required by ``Interactable``. Holds active-state, bound tasks, and the `AsyncStream` continuations. |
 | `private var cancellables = Set<AnyCancellable>()` | *(deleted)* | Combine is gone. Bound tasks via ``Interactable/task(priority:_:)`` replace `disposeOnDeactivate`. |
 | `override func didBecomeActive() { super.didBecomeActive(); … }` | `func didBecomeActive() async { … }` | No `super` to call. ``Interactable/didBecomeActive()``'s default impl is a no-op; your body is the override. |
-| `userPublisher.sink { … }.store(in: &cancellables)` | `task { for await user in userService.userStream { … } }` | `for await` over an `AsyncStream` replaces Combine subscription. The `task { ... }` binds it to the active scope. |
+| `userPublisher.sink { … }.store(in: &cancellables)` | `task { for await user in userService.userStream() { … } }` | `for await` over an `AsyncStream` replaces Combine subscription. The `task { ... }` binds it to the active scope. |
 | `override func willResignActive() { super.willResignActive(); cancellables.removeAll() }` | `func willResignActive() async { … }` | No manual task cancellation — the lifecycle cancels bound tasks automatically *after* `willResignActive()` returns. |
 | `presenter.update(user: user)` (sync) | `await presenter.update(user: user)` | Presenter is `@MainActor`; the interactor is an actor. Crossing requires `await`. |
 | `init(...) { … presenter.listener = self }` | `await MainActor.run { presenter.listener = self }` inside `didBecomeActive()` | The presenter is `@MainActor`; setting its listener requires being on the main actor. Doing it in `didBecomeActive()` (rather than `init`) also keeps the wiring tied to the active scope. |

--- a/Sources/napkin/napkin.docc/Articles/MigratingFromV0.md
+++ b/Sources/napkin/napkin.docc/Articles/MigratingFromV0.md
@@ -229,6 +229,8 @@ A typical v0.x file set on the left, the v2.0.0 equivalent on the right. Treat e
 | `protocol HomeListener { func homeDidLogout() }` | `protocol HomeListener: AnyObject, Sendable { func homeDidLogout() async }` | Listeners cross isolation domains (parent's actor). They are `Sendable` and their methods are `async`. |
 | `attachChild(r)` (sync) | `await attachChild(r)` | ``Routing/attachChild(_:)`` is `async` because it awaits the child's ``Interactable/activate()``. |
 | `super.init(interactor: interactor, viewController: viewController)` in router | Same | ``ViewableRouter`` is still a class; this initializer is unchanged. |
+| `CurrentValueSubject` on a service | `actor` service vending replay-latest `AsyncStream`s (fresh stream per subscriber) | Producer recipes in <doc:StreamingStateDownTheTree>. |
+| `PassthroughSubject` | The same fan-out actor, minus the initial `yield` | No replay. |
 
 ## What you don't have to change
 

--- a/Sources/napkin/napkin.docc/Articles/StreamingStateDownTheTree.md
+++ b/Sources/napkin/napkin.docc/Articles/StreamingStateDownTheTree.md
@@ -1,6 +1,6 @@
 # Streaming State Down the Tree
 
-How to replace Combine's `CurrentValueSubject`, `PassthroughSubject`, and `@Published` with actor-owned `AsyncStream`s and `Observations` sequences, consumed through ``Interactable/task(priority:_:)`` — the same lifecycle-bound primitive behind the framework's own ``InteractorScope/isActiveStream``.
+How to replace Combine's `CurrentValueSubject`, `PassthroughSubject`, and `@Published` with actor-owned `AsyncStream`s and `Observations` sequences, consumed through lifecycle-bound ``Interactable/task(priority:_:)`` loops. The state recipe mirrors the shape of the framework's own ``InteractorScope/isActiveStream``.
 
 ## Overview
 

--- a/Sources/napkin/napkin.docc/Articles/StreamingStateDownTheTree.md
+++ b/Sources/napkin/napkin.docc/Articles/StreamingStateDownTheTree.md
@@ -6,7 +6,7 @@ How to replace Combine's `CurrentValueSubject`, `PassthroughSubject`, and `@Publ
 
 Data flows down the napkin tree; events flow up through listener protocols. Build-time injection covers a child's *initial* values — but for values that keep changing (auth state, session data, totals), Combine-era napkin put a subject on a service, shared the service through the parent's ``Component``, and let each interested interactor subscribe. That architecture is unchanged: the service is still created once with ``Component/shared(forCallerKey:_:)`` and threaded down through ``Dependency`` protocols. Only the streaming primitive changes — and **state** (has a current value) and **events** (fire-and-forget) get different tools.
 
-> Note: Every code block on this page is copied from the `snippet.show` region of a file under `Snippets/Streaming/`; `swift build` compiles them, so the examples here can't silently drift from working code. This article mirrors README.md's identically-titled section.
+> Note: Every napkin 2.x code block on this page is copied from the `snippet.show` region of a file under `Snippets/Streaming/`; `swift build` compiles them, so the examples here can't silently drift from working code. This article mirrors README.md's identically-titled section.
 
 | Combine | napkin 2.x | Notes |
 |---|---|---|
@@ -19,7 +19,7 @@ Data flows down the napkin tree; events flow up through listener protocols. Buil
 | `.catch { presentError(…); return Just(fallback) }` | `do { for try await … } catch { await presenter.presentError(…) }` | Both are terminal — emit a fallback in the `catch` if you need one |
 | `.map` / transforms mid-pipeline | Plain code in the loop body | It's just a `for` loop |
 | `.receive(on: DispatchQueue.main)` | `await presenter.…` | The presenter is `@MainActor`; the crossing is explicit |
-| `assign(to:on:)` / nested `ObservableObject` view model | Set the `@Observable` presenter property; SwiftUI reads via `@Bindable` | The view-model layer disappears |
+| `assign(to:on:)` / nested `ObservableObject` view model | Set the `@Observable` presenter property; SwiftUI reads it directly | The view-model layer disappears |
 | `tapSubject` on the SwiftUI view + `.sink` in the VC | `dispatch { await listener?.didTapX() }` | See <doc:SwiftUIIntegration> |
 | `publisher(for: \.keyPath)` (KVO on UIKit objects) | The UIKit override/callback KVO was wrapping + `dispatch {}` | Not every pipe becomes a stream |
 | `combineLatest` / `merge` / `debounce` / `removeDuplicates` | [swift-async-algorithms](https://github.com/apple/swift-async-algorithms) | Official Apple package, not part of the standard library |
@@ -28,7 +28,7 @@ Data flows down the napkin tree; events flow up through listener protocols. Buil
 
 The producer side — the half Combine users already wrote themselves and 2.x docs never showed. A service actor owns the current value and fans out to any number of subscribers:
 
-### The 0.x version this replaces
+### The 0.x producer this replaces
 
 ```swift
 // The manager owned a subject; errors terminated it, so the manager
@@ -174,9 +174,9 @@ Teardown is a closed loop with no leak path: detaching the napkin cancels the `t
 
 ## From the service to the screen
 
-One value crosses four seams on its way to a pixel: service → interactor (`task { for await }`), interactor → presenter (an `await`ed async method), presenter → view (`@Observable` read via `@Bindable`), and view → interactor (`dispatch {}`). Here a second napkin, deeper in the tree, subscribes to the *same* service — each `userStream()` call is an independent stream, so fan-out just works. Because every stream starts with the current value, a napkin attached after login learns the auth state immediately — an upgrade over the PassthroughSubject original, where late subscribers waited for the next change. It carries the value through the presenter into SwiftUI:
+One value crosses four seams on its way to a pixel: service → interactor (`task { for await }`), interactor → presenter (an `await`ed async method), presenter → view (a direct `@Observable` read), and view → interactor (`dispatch {}`). Here a second napkin, deeper in the tree, subscribes to the *same* service — each `userStream()` call is an independent stream, so fan-out just works. Because every stream starts with the current value, a napkin attached after login learns the auth state immediately — an upgrade over the PassthroughSubject original, where late subscribers waited for the next change. It carries the value through the presenter into SwiftUI:
 
-### The 0.x version this replaces
+### The 0.x pipeline this replaces
 
 ```swift
 // The presentable protocol exposed subjects…
@@ -261,7 +261,7 @@ struct ProfileView: View {
 Three notes from real migrations:
 
 - **Many subjects collapse into one presenter.** Parallel subjects (`institutions`, `rank`, `user`) become stored properties on a single presenter — several pipes become several properties, not several streams. Collections included: `var institutions: [Institution]` drives `ForEach` directly, and per-subview view-model construction disappears (child views take presenter properties as plain values).
-- **Formatting moves into the presenter.** 0.x ran `compactMap { currencyFormatter.string(from:) }` inside view-controller pipelines; that transform belongs in the presenter method — which is the ``Presenter`` class's stated job. Where the hosting controller also feeds UIKit chrome (a navigation title, a bar-button label), the same presenter serves both: `@Bindable` for SwiftUI, `Observations {}` for UIKit — see <doc:SwiftUIIntegration>.
+- **Formatting moves into the presenter.** 0.x ran `compactMap { currencyFormatter.string(from:) }` inside view-controller pipelines; that transform belongs in the presenter method — which is the ``Presenter`` class's stated job. Where the hosting controller also feeds UIKit chrome (a navigation title, a bar-button label), the same presenter serves both: a direct read for SwiftUI, `Observations {}` for UIKit — see <doc:SwiftUIIntegration>.
 - **Animations.** `.transition` / `.animation(value:)` on the view keep working. Where 0.x relied on implicit animation from `objectWillChange`, wrap the mutation in `withAnimation` inside the presenter method — it's `@MainActor`, so this is legal and local.
 
 ## Events: replacing PassthroughSubject

--- a/Sources/napkin/napkin.docc/Articles/StreamingStateDownTheTree.md
+++ b/Sources/napkin/napkin.docc/Articles/StreamingStateDownTheTree.md
@@ -1,0 +1,425 @@
+# Streaming State Down the Tree
+
+How to replace Combine's `CurrentValueSubject`, `PassthroughSubject`, and `@Published` with actor-owned `AsyncStream`s and `Observations` sequences, consumed through ``Interactable/task(priority:_:)`` — the same lifecycle-bound primitive behind the framework's own ``InteractorScope/isActiveStream``.
+
+## Overview
+
+Data flows down the napkin tree; events flow up through listener protocols. Build-time injection covers a child's *initial* values — but for values that keep changing (auth state, session data, totals), Combine-era napkin put a subject on a service, shared the service through the parent's ``Component``, and let each interested interactor subscribe. That architecture is unchanged: the service is still created once with ``Component/shared(forCallerKey:_:)`` and threaded down through ``Dependency`` protocols. Only the streaming primitive changes — and **state** (has a current value) and **events** (fire-and-forget) get different tools.
+
+> Note: Every code block on this page is copied from the `snippet.show` region of a file under `Snippets/Streaming/`; `swift build` compiles them, so the examples here can't silently drift from working code. This article mirrors README.md's identically-titled section.
+
+| Combine | napkin 2.x | Notes |
+|---|---|---|
+| `CurrentValueSubject` | `actor` service vending replay-latest streams | Replays current value; a fresh stream per subscriber |
+| `@Published` / `ObservableObject` | `@Observable` service + `Observations {}` | Multi-consumer; each iterator starts with the current value |
+| `PassthroughSubject` | The same fan-out actor, minus the initial `yield` | No replay |
+| `.sink {}.store(in: &cancellables)` | `task { for await … }` | Auto-cancelled on deactivate |
+| `.subscribe(presenter.someSubject)` | `await presenter.present(…)` in the loop body | Presentable protocols expose async methods, not subjects |
+| `.catch` / `.retry` / subject `reset()` | `async throws` at the call site | Streams carry state, not failure; they never terminate on error |
+| `.catch { presentError(…); return Just(fallback) }` | `do { for try await … } catch { await presenter.presentError(…) }` | Both are terminal — emit a fallback in the `catch` if you need one |
+| `.map` / transforms mid-pipeline | Plain code in the loop body | It's just a `for` loop |
+| `.receive(on: DispatchQueue.main)` | `await presenter.…` | The presenter is `@MainActor`; the crossing is explicit |
+| `assign(to:on:)` / nested `ObservableObject` view model | Set the `@Observable` presenter property; SwiftUI reads via `@Bindable` | The view-model layer disappears |
+| `tapSubject` on the SwiftUI view + `.sink` in the VC | `dispatch { await listener?.didTapX() }` | See <doc:SwiftUIIntegration> |
+| `publisher(for: \.keyPath)` (KVO on UIKit objects) | The UIKit override/callback KVO was wrapping + `dispatch {}` | Not every pipe becomes a stream |
+| `combineLatest` / `merge` / `debounce` / `removeDuplicates` | [swift-async-algorithms](https://github.com/apple/swift-async-algorithms) | Official Apple package, not part of the standard library |
+
+## State: replacing CurrentValueSubject
+
+The producer side — the half Combine users already wrote themselves and 2.x docs never showed. A service actor owns the current value and fans out to any number of subscribers:
+
+### The 0.x version this replaces
+
+```swift
+// The manager owned a subject; errors terminated it, so the manager
+// grew a reset() that swapped in a fresh subject…
+protocol AuthenticationManaging {
+    var userSubject: PassthroughSubject<User?, Error> { get }
+    func reset() -> AuthenticationManager
+    func signIn()
+    func signOut()
+}
+
+// …and every subscriber needed catch/retry ceremony to survive:
+authenticationManager.userSubject
+    .catch { error -> PassthroughSubject<User?, Error> in
+        self.presenter.presentError(error: error)
+        return self.authenticationManager.reset().userSubject
+    }
+    .retry(.max)
+    .assertNoFailure()
+    .sink(receiveValue: handleUser)
+    .store(in: &cancellables)
+```
+
+```swift
+/// Replaces `CurrentValueSubject`: replays the current value to each new
+/// subscriber, fans out to any number of subscribers, and never
+/// terminates on error. Same shape as the framework's own
+/// `isActiveStream`. The actor is the lock — no `Mutex`, no
+/// `@unchecked Sendable`.
+actor AuthenticationService {
+
+    private(set) var currentUser: User?
+    private var subscribers: [UUID: AsyncStream<User?>.Continuation] = [:]
+
+    /// A fresh stream per subscriber: the current value immediately,
+    /// then every change. `AsyncStream` is single-consumer — vending a
+    /// new stream per call is what makes fan-out safe.
+    func userStream() -> AsyncStream<User?> {
+        let (stream, continuation) = AsyncStream.makeStream(of: User?.self)
+        let id = UUID()
+        subscribers[id] = continuation
+        continuation.yield(currentUser)
+        continuation.onTermination = { [weak self] _ in
+            Task { await self?.removeSubscriber(id) }
+        }
+        return stream
+    }
+
+    /// Errors surface here, at the call site that asked — not on the
+    /// stream. This is why the Combine version's catch/reset/retry
+    /// ceremony has no translation: it has no job left.
+    func signIn(name: String) async throws -> User {
+        let user = User(name: name)   // e.g. try await backend.signIn()
+        setUser(user)
+        return user
+    }
+
+    func signOut() async throws {
+        setUser(nil)                  // e.g. try await backend.signOut()
+    }
+
+    /// Adapting a callback API — the 0.x manager wrapped an auth
+    /// SDK's state-change listener; the 2.x service hops the callback
+    /// onto the actor:
+    func bind(to auth: AuthClient) {
+        auth.addStateDidChangeListener { user in
+            Task { await self.setUser(user) }
+        }
+    }
+
+    private func setUser(_ user: User?) {
+        currentUser = user
+        for continuation in subscribers.values {
+            continuation.yield(user)
+        }
+    }
+
+    private func removeSubscriber(_ id: UUID) {
+        subscribers[id]?.finish()
+        subscribers.removeValue(forKey: id)
+    }
+}
+```
+
+Share it exactly as before — ``Component/shared(forCallerKey:_:)`` in the parent's ``Component``, forwarded through child ``Dependency`` protocols:
+
+```swift
+protocol RootDependency: Dependency {}
+
+final class RootComponent: Component<RootDependency>, @unchecked Sendable {
+    var authService: AuthenticationService {
+        shared { AuthenticationService() }
+    }
+}
+
+protocol ProfileDependency: Dependency {
+    var authService: AuthenticationService { get }
+}
+
+extension RootComponent: ProfileDependency {}
+```
+
+The root napkin's interactor is the auth gate — one lifecycle-bound subscription drives routing:
+
+```swift
+@MainActor
+protocol RootRouting: ViewableRouting, Sendable {
+    func routeToHome(user: User) async
+    func routeToLogin() async
+}
+
+final actor RootInteractor: Interactable {
+
+    nonisolated let lifecycle = InteractorLifecycle()
+
+    weak var router: RootRouting?
+
+    private let authService: AuthenticationService
+
+    init(authService: AuthenticationService) {
+        self.authService = authService
+    }
+
+    func didBecomeActive() async {
+        // One long-lived subscription drives routing. Bound to the
+        // active scope: cancelled automatically on willResignActive.
+        task {
+            for await user in await self.authService.userStream() {
+                if let user {
+                    await self.router?.routeToHome(user: user)
+                } else {
+                    await self.router?.routeToLogin()
+                }
+            }
+        }
+    }
+}
+```
+
+Note what happened to the error handling: nothing replaced it. `signIn()` is `async throws`, so failures return to the call site that asked; the stream carries only state and can never terminate on error. The `catch`/`retry`/`reset()` chain isn't translated — it's deleted.
+
+Teardown is a closed loop with no leak path: detaching the napkin cancels the `task {}`, cancellation fires the stream's `onTermination`, and `onTermination` removes the subscriber from the actor's table.
+
+## From the service to the screen
+
+One value crosses four seams on its way to a pixel: service → interactor (`task { for await }`), interactor → presenter (an `await`ed async method), presenter → view (`@Observable` read via `@Bindable`), and view → interactor (`dispatch {}`). Here a second napkin, deeper in the tree, subscribes to the *same* service — each `userStream()` call is an independent stream, so fan-out just works. Because every stream starts with the current value, a napkin attached after login learns the auth state immediately — an upgrade over the PassthroughSubject original, where late subscribers waited for the next change. It carries the value through the presenter into SwiftUI:
+
+### The 0.x version this replaces
+
+```swift
+// The presentable protocol exposed subjects…
+protocol ProfilePresentable: Presentable {
+    var greeting: PassthroughSubject<String, Never> { get }
+}
+
+// …the interactor piped into them…
+userManager.userPublisher
+    .map { user in user.map { "Welcome back, \($0.name)" } ?? "Signed out" }
+    .subscribe(presenter.greeting)
+    .store(in: &cancellables)
+
+// …and the hosting controller re-piped into a nested view model:
+greeting
+    .receive(on: DispatchQueue.main)
+    .assign(to: \.viewModel.greeting, on: rootView)
+    .store(in: &cancellables)
+```
+
+```swift
+protocol ProfilePresentable: Presentable, Sendable {
+    func present(greeting: String) async
+}
+
+final actor ProfileInteractor: PresentableInteractable {
+
+    nonisolated let lifecycle = InteractorLifecycle()
+    nonisolated let presenter: ProfilePresentable
+
+    private let authService: AuthenticationService
+
+    init(presenter: ProfilePresentable, authService: AuthenticationService) {
+        self.presenter = presenter
+        self.authService = authService
+    }
+
+    func didBecomeActive() async {
+        task {
+            // A second, independent stream from the same service: the
+            // root gate above and this napkin both see every change.
+            for await user in await self.authService.userStream() {
+                // What `.map` did mid-pipeline is now plain code.
+                let greeting = user.map { "Welcome back, \($0.name)" } ?? "Signed out"
+                // The `await` is the main-actor crossing — this is
+                // where `.receive(on: DispatchQueue.main)` went.
+                await self.presenter.present(greeting: greeting)
+            }
+        }
+    }
+}
+```
+
+The presenter *is* the view model. Its `@Observable` stored property replaces the subject, the `assign`, the nested `ObservableObject`, and the `receive(on: main)` — SwiftUI reads it directly. Hold the presenter weakly (it owns the view controller that owns the view), and rebind with `@Bindable` inside `body` when you need two-way bindings:
+
+```swift
+@MainActor
+@Observable
+final class ProfilePresenter: Presenter<ProfileViewController>, ProfilePresentable {
+
+    var greeting: String = ""
+
+    func present(greeting: String) async {
+        self.greeting = greeting
+    }
+}
+
+struct ProfileView: View {
+    // Weak: the presenter owns the view controller, which owns this view —
+    // a strong reference here would be a retain cycle. The interactor keeps
+    // the presenter alive for the napkin's whole attached lifetime.
+    weak var presenter: ProfilePresenter?
+
+    var body: some View {
+        Text(presenter?.greeting ?? "")
+    }
+}
+```
+
+(``Presenter``'s generic argument is your concrete hosting controller — here `ProfileViewController`, built by the feature's builder. A protocol can't satisfy it: existentials don't conform to their own protocols.)
+
+Three notes from real migrations:
+
+- **Many subjects collapse into one presenter.** Parallel subjects (`institutions`, `rank`, `user`) become stored properties on a single presenter — several pipes become several properties, not several streams. Collections included: `var institutions: [Institution]` drives `ForEach` directly, and per-subview view-model construction disappears (child views take presenter properties as plain values).
+- **Formatting moves into the presenter.** 0.x ran `compactMap { currencyFormatter.string(from:) }` inside view-controller pipelines; that transform belongs in the presenter method — which is the ``Presenter`` class's stated job. Where the hosting controller also feeds UIKit chrome (a navigation title, a bar-button label), the same presenter serves both: `@Bindable` for SwiftUI, `Observations {}` for UIKit — see <doc:SwiftUIIntegration>.
+- **Animations.** `.transition` / `.animation(value:)` on the view keep working. Where 0.x relied on implicit animation from `objectWillChange`, wrap the mutation in `withAnimation` inside the presenter method — it's `@MainActor`, so this is legal and local.
+
+## Events: replacing PassthroughSubject
+
+Fire-and-forget events (no current value, no replay) are the same fan-out actor minus the replay:
+
+```swift
+enum AuthEvent: Sendable {
+    case sessionExpired
+    case passwordChanged
+}
+
+/// Replaces `PassthroughSubject`: the same fan-out actor, minus the
+/// replay. New subscribers see only events sent after they subscribed.
+actor AuthEventBus {
+
+    private var subscribers: [UUID: AsyncStream<AuthEvent>.Continuation] = [:]
+
+    func events() -> AsyncStream<AuthEvent> {
+        let (stream, continuation) = AsyncStream.makeStream(of: AuthEvent.self)
+        let id = UUID()
+        subscribers[id] = continuation
+        // No stored current value and no initial yield — the replay
+        // is the whole difference between CurrentValueSubject and
+        // PassthroughSubject.
+        continuation.onTermination = { [weak self] _ in
+            Task { await self?.removeSubscriber(id) }
+        }
+        return stream
+    }
+
+    func send(_ event: AuthEvent) {
+        for continuation in subscribers.values {
+            continuation.yield(event)
+        }
+    }
+
+    private func removeSubscriber(_ id: UUID) {
+        subscribers[id]?.finish()
+        subscribers.removeValue(forKey: id)
+    }
+}
+
+// Consumed exactly like state — a lifecycle-bound task:
+final actor SessionMonitorInteractor: Interactable {
+
+    nonisolated let lifecycle = InteractorLifecycle()
+
+    private let eventBus: AuthEventBus
+
+    init(eventBus: AuthEventBus) {
+        self.eventBus = eventBus
+    }
+
+    func didBecomeActive() async {
+        task {
+            for await event in await self.eventBus.events() {
+                await self.handle(event)
+            }
+        }
+    }
+
+    private func handle(_ event: AuthEvent) { /* … */ }
+}
+```
+
+> Warning: `AsyncStream` is single-consumer. Concurrent iteration of one `AsyncStream` instance is a programmer error ([SE-0314](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0314-async-stream.md)). Never store one stream and hand it to multiple subscribers — vend a fresh stream per subscriber, as both recipes above do. Combine publishers multicast; streams don't.
+
+## Main-actor state: @Observable + Observations
+
+```swift
+/// When state is main-actor-friendly anyway — view-adjacent session
+/// state, say — skip the hand-rolled fan-out. An `@Observable` class
+/// plus `Observations` gives you `CurrentValueSubject` semantics for
+/// free: each iterator starts with the current value, and any number
+/// of consumers can observe independently.
+@MainActor
+@Observable
+final class SessionService {
+
+    private(set) var currentUser: User?
+
+    func set(user: User?) {
+        currentUser = user
+    }
+}
+
+final actor SettingsInteractor: Interactable {
+
+    nonisolated let lifecycle = InteractorLifecycle()
+
+    private let sessionService: SessionService
+
+    init(sessionService: SessionService) {
+        self.sessionService = sessionService
+    }
+
+    func didBecomeActive() async {
+        // The observation loop runs on the actor that owns the state —
+        // bind it to the main actor, and hop back to this actor to
+        // handle each value. Still lifecycle-bound: cancelled on
+        // willResignActive.
+        let sessionService = self.sessionService
+        task { @MainActor [weak self] in
+            for await user in Observations({ sessionService.currentUser }) {
+                await self?.handle(user)
+            }
+        }
+    }
+
+    private func handle(_ user: User?) { /* … */ }
+}
+```
+
+`Observations` ([SE-0475](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0475-observed.md)) is multi-consumer and primes each iterator with the current value — `CurrentValueSubject` semantics without writing a broadcaster. The trade-off: the state lives on the main actor, which is right for view-adjacent session state and wrong for business state that belongs off it (see <doc:CrossIsolationPatterns>).
+
+## Not everything becomes a stream
+
+Combine's KVO publishers were wrapping UIKit callbacks; 2.x uses the callbacks:
+
+```swift
+@MainActor
+final class ProfileViewController: UIViewController {
+
+    weak var listener: ProfilePresentableListener?
+
+    // 0.x observed UIKit with Combine's KVO publisher:
+    //
+    //     publisher(for: \.parent)
+    //         .sink { [weak self] parent in
+    //             if parent == nil { self?.listener?.didDismiss() }
+    //         }
+    //         .store(in: &cancellables)
+    //
+    // 2.x uses the UIKit callback that KVO was wrapping:
+    override func didMove(toParent parent: UIViewController?) {
+        super.didMove(toParent: parent)
+        if parent == nil {
+            dispatch { [listener] in await listener?.didDismiss() }
+        }
+    }
+}
+```
+
+Tap enums with associated values (`case institution(itemId:institutionId:)`) get the same treatment: they become listener methods with parameters, and the enum-plus-`switch` ceremony deletes.
+
+For operator-heavy pipelines — `combineLatest`, `merge`, `debounce`, `removeDuplicates` — reach for [swift-async-algorithms](https://github.com/apple/swift-async-algorithms), Apple's official package of `AsyncSequence` algorithms. Migration mechanics beyond streaming live in <doc:MigratingFromV0>; lifecycle binding rules in <doc:Lifecycle>; the `task {}` vs `Task {}` decision rules in <doc:CrossIsolationPatterns>.
+
+## Cross-references
+
+- ``Interactable/task(priority:_:)`` — the lifecycle-bound task every recipe on this page subscribes from.
+- ``InteractorScope/isActiveStream`` — the framework's own instance of the replay-latest, fan-out pattern shown in the producer recipe above.
+- ``Component`` / ``Dependency`` — how the streaming service is shared down the tree, unchanged from before.
+- ``Presenter`` — the `@Observable` view-state holder the consumer recipes present into.
+
+## See Also
+
+- <doc:MigratingFromV0>
+- <doc:Lifecycle>
+- <doc:CrossIsolationPatterns>
+- <doc:SwiftUIIntegration>

--- a/Sources/napkin/napkin.docc/Articles/SwiftUIIntegration.md
+++ b/Sources/napkin/napkin.docc/Articles/SwiftUIIntegration.md
@@ -38,7 +38,7 @@ final class HomePresenter: Presenter<HomeViewController>, HomePresentable {
 }
 ```
 
-The SwiftUI view receives the presenter as a `@Bindable` and reads stored properties directly. SwiftUI invalidates only the parts of the view that read mutated properties.
+The SwiftUI view holds the presenter weakly — the presenter owns the view controller that owns the view, so a strong stored reference would be a retain cycle — and reads its `@Observable` properties directly, rebinding with `@Bindable` inside `body` only when it needs two-way bindings. SwiftUI invalidates only the parts of the view that read mutated properties.
 
 ```swift
 struct HomeView: View {
@@ -60,7 +60,7 @@ struct HomeView: View {
 }
 ```
 
-**Why `@Bindable` and not `@ObservedObject`.** `@Observable` types are not `ObservableObject`. Use `@Bindable` for two-way bindings (`$presenter.foo`) or read directly via `presenter.foo`. There is no `.environmentObject` plumbing — the presenter is just passed in as a property.
+**Why Observation and not `@ObservedObject`.** `@Observable` types are not `ObservableObject` — Observation tracks reads on its own, so no property wrapper is needed to observe: read directly via `presenter?.foo`. For two-way bindings, rebind inside `body` (`if let presenter { @Bindable var presenter = presenter; ... $presenter.foo ... }`). There is no `.environmentObject` plumbing — the presenter is just passed in as a property.
 
 **Why `@MainActor` on the presenter.** SwiftUI reads from `@Observable` synchronously during `body` evaluation. The presenter's storage must be readable on the main actor. Marking the class `@MainActor` makes that guarantee explicit.
 

--- a/Sources/napkin/napkin.docc/Articles/SwiftUIIntegration.md
+++ b/Sources/napkin/napkin.docc/Articles/SwiftUIIntegration.md
@@ -6,7 +6,7 @@ How `@Observable` presenters consume state without Combine, the `Observations { 
 
 napkin doesn't import Combine. The interactor → presenter path uses `async` methods; the presenter → view path uses Observation (the `@Observable` macro). This article explains the consuming patterns for SwiftUI and UIKit, and the small set of pitfalls that have bitten people.
 
-## `@Observable` Presenter + `@Bindable` View
+## The `@Observable` Presenter, Held Weakly
 
 When a feature is large enough to want a dedicated presenter object, subclass ``Presenter`` and add stored properties for view state. ``Presenter`` is `@Observable`, so SwiftUI sees mutations automatically. Subclasses re-annotate `@Observable` so their own stored properties are tracked too.
 

--- a/Sources/napkin/napkin.docc/Articles/SwiftUIIntegration.md
+++ b/Sources/napkin/napkin.docc/Articles/SwiftUIIntegration.md
@@ -8,7 +8,7 @@ napkin doesn't import Combine. The interactor → presenter path uses `async` me
 
 ## `@Observable` Presenter + `@Bindable` View
 
-When a feature is large enough to want a dedicated presenter object, subclass ``Presenter`` and add stored properties for view state. ``Presenter`` is `@Observable`, so SwiftUI sees mutations automatically.
+When a feature is large enough to want a dedicated presenter object, subclass ``Presenter`` and add stored properties for view state. ``Presenter`` is `@Observable`, so SwiftUI sees mutations automatically. Subclasses re-annotate `@Observable` so their own stored properties are tracked too.
 
 ```swift
 import napkin
@@ -42,19 +42,19 @@ The SwiftUI view receives the presenter as a `@Bindable` and reads stored proper
 
 ```swift
 struct HomeView: View {
-    @Bindable var presenter: HomePresenter
+    weak var presenter: HomePresenter?
     weak var listener: HomeViewListener?
 
     var body: some View {
         VStack {
-            Text(presenter.displayName)
-            if let error = presenter.errorMessage {
+            Text(presenter?.displayName ?? "")
+            if let error = presenter?.errorMessage {
                 Text(error).foregroundStyle(.red)
             }
             Button("Logout") {
                 dispatch { [listener] in await listener?.didTapLogout() }
             }
-            .disabled(presenter.isLoggingOut)
+            .disabled(presenter?.isLoggingOut ?? false)
         }
     }
 }

--- a/Sources/napkin/napkin.docc/napkin.md
+++ b/Sources/napkin/napkin.docc/napkin.md
@@ -64,6 +64,7 @@ A runnable end-to-end reference, **Napkin's Rib House**, lives at `Examples/RibH
 - <doc:TutorialBuildingALoginFlow>
 - <doc:DefiningAFeature>
 - <doc:MigratingFromV0>
+- <doc:StreamingStateDownTheTree>
 
 ### Tutorials
 

--- a/Tools/site/llms.txt
+++ b/Tools/site/llms.txt
@@ -11,6 +11,7 @@
 - [Adding a Networked Service](https://getnapkin.to/documentation/napkin/addinganetworkedservice): Swap the example's BarbecueAuthService mock for a real URLSession-backed implementation. The napkin tree above the service doesn't change.
 - [Tab Bar Napkin](https://getnapkin.to/documentation/napkin/tabbarnapkin): Concurrent routing pattern — a parent napkin holds N child napkin builders, all attached at once, hosted in a UITabBarController.
 - [Migrating from V0](https://getnapkin.to/documentation/napkin/migratingfromv0): Side-by-side diffs for converting older RIBs/Combine code to napkin's Swift Concurrency idioms.
+- [Streaming State Down the Tree](https://getnapkin.to/documentation/napkin/streamingstatedownthetree): Replacing `CurrentValueSubject`/`PassthroughSubject`/`@Published` with actor-owned `AsyncStream`s and `Observations`, consumed via lifecycle-bound `task {}`.
 
 ## Architecture
 

--- a/docs/superpowers/plans/2026-07-02-streaming-follow-ups.md
+++ b/docs/superpowers/plans/2026-07-02-streaming-follow-ups.md
@@ -1,0 +1,103 @@
+# Streaming Follow-Ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox syntax.
+
+**Goal:** Close out the review-queued follow-ups from PRs #150/#151: fix the leaking presenter shape in the published recipe, stop the CHANGELOG from recommending a compiler-crashing pattern, align older DocC articles with the new canonical spellings, lift the streaming section into a DocC article with producer rows in the migration table, and capture the simulator run recipe as a project skill.
+
+**Architecture:** One branch (`docs/streaming-follow-ups`), docs + snippet + one project-skill file; no behavior changes anywhere. README code blocks stay token-mirrors of `Snippets/Streaming/*` shown regions (CI-compiled). Upstream context: the Observations crash is now swiftlang/swift#90370; repo issues #153/#154 track the framework-level items (NOT in this branch).
+
+**Tech Stack:** Markdown/DocC, Swift snippet edit, `swift build`/`swift test`, `swift package generate-documentation`.
+
+## Global Constraints
+
+- README Swift blocks must remain token-for-token mirrors of the snippets' `// snippet.show` regions — edit the snippet first, mirror second.
+- No framework `.swift` code changes; `Sources/napkin/Presenter.swift` doc-COMMENT edits only.
+- The weak-presenter guidance everywhere is: store the presenter `weak` in the view (the presenter owns the VC that owns the view); read properties directly (`presenter?.x`); rebind locally with `@Bindable` inside `body` only when two-way bindings are needed.
+- Commits: imperative subject + why + trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`. Cruft-clean before each commit: `find /Users/nonplus/Desktop/napkin \( -name "* 2.*" -o -name "* 3.*" \) -not -path "*/.build/*" -print0 | xargs -0 rm -rf`
+- Verify per task: `swift build && swift test` (Task 1 — it touches a compiled snippet) and `swift package generate-documentation --target napkin 2>&1 | tail -3` (Tasks 1–2; no new errors).
+
+---
+
+### Task 1: Corrections — weak presenter, CHANGELOG, DocC alignment
+
+**Files:**
+- Modify: `Snippets/Streaming/AuthStateStreaming.swift` (ProfileView block)
+- Modify: `README.md` (mirror + two guidance sentences)
+- Modify: `Sources/napkin/Presenter.swift` (doc comment example + one sentence)
+- Modify: `Sources/napkin/napkin.docc/Articles/SwiftUIIntegration.md` (example + one sentence)
+- Modify: `CHANGELOG.md` (2.0.0 migration step 4)
+- Modify: `Sources/napkin/napkin.docc/Articles/Lifecycle.md`, `MigratingFromV0.md`, `HeadlessNapkins.md` (spelling alignment + Sendable)
+
+- [ ] **Step 1: Snippet — weak presenter.** In `AuthStateStreaming.swift`, replace the `ProfileView` shown block with:
+
+```swift
+struct ProfileView: View {
+    // Weak: the presenter owns the view controller, which owns this view —
+    // a strong reference here would be a retain cycle. The interactor keeps
+    // the presenter alive for the napkin's whole attached lifetime.
+    weak var presenter: ProfilePresenter?
+
+    var body: some View {
+        Text(presenter?.greeting ?? "")
+    }
+}
+```
+
+Mirror the same block into README's "From the service to the screen" section, token-for-token.
+
+- [ ] **Step 2: README guidance sentences.** (a) In the paragraph after that block ("The presenter *is* the view model…"), append: `Hold it weakly — the presenter owns the view controller that owns the view; rebind with `@Bindable` inside `body` when you need two-way bindings.` (b) In SwiftUI Integration's paragraph ending "…Re-annotate the subclass with `@Observable` so its stored properties are tracked.", change the earlier clause "let the view read the presenter via `@Bindable`" to "let the view hold the presenter `weak` and read its properties directly".
+
+- [ ] **Step 3: Presenter.swift doc comment.** In the "Read it from SwiftUI" example (~line 112), change `@Bindable var presenter: HomePresenter` to `weak var presenter: HomePresenter?` and the body reads to optional (`presenter?.displayName ?? ""`; wrap the Button's listener call unchanged). Immediately before that example, add one doc line: `/// Hold the presenter weakly — it owns the view controller that owns the view. Rebind with `@Bindable` inside `body` for two-way bindings.` In the Overview's presenter-subclass bullet, append: `Re-annotate subclasses with `@Observable` so their own stored properties are tracked.`
+
+- [ ] **Step 4: SwiftUIIntegration.md.** Find the `HomePresenter`/`@Bindable var presenter` example(s); apply the same weak-presenter change and, in the prose near line 10 ("``Presenter`` is `@Observable`, so SwiftUI sees mutations automatically"), append: `Subclasses re-annotate `@Observable` so their own stored properties are tracked too.`
+
+- [ ] **Step 5: CHANGELOG step 4.** Replace the 2.0.0 migration guide's step 4 with:
+
+```
+4. Replace `cancellables` and Combine `.sink { … }` subscriptions with
+   lifecycle-bound tasks inside `didBecomeActive`: `task { for await … in
+   service.stream() { … } }` for service streams, or — for `@Observable`
+   state — `task { @MainActor [weak self] in for await … in
+   Observations({ … }) { … } }`. The observation loop must be bound to the
+   actor that owns the state; iterating `Observations` directly inside the
+   nonisolated `task {}` closure crashes the current Swift 6 compiler
+   ([swiftlang/swift#90370](https://github.com/swiftlang/swift/issues/90370)).
+   Tasks are auto-cancelled on `deactivate`.
+```
+
+- [ ] **Step 6: DocC alignment.** (a) `Lifecycle.md`, `MigratingFromV0.md`: every `userService.userStream` (parenless, in code or backticked prose) → `userService.userStream()`. (b) `HeadlessNapkins.md`: `self.eventBus.events` → `self.eventBus.events()` (and any parenless prose mention). (c) `MigratingFromV0.md` line ~30: `protocol HomeRouting: ViewableRouting {` → `protocol HomeRouting: ViewableRouting, Sendable {` — this is in the v2 "after" column/fence only; do not edit 0.x "before" code.
+
+- [ ] **Step 7: Verify + commit.** `swift build && swift test` green; docs build green; README block diffed against snippet shown region (0 differences). Commit: `docs: weak-presenter recipe, CHANGELOG crash fix, DocC spelling alignment` + body (why: recipe taught the retain cycle #151 fixed in the app; CHANGELOG step 4 recommended the swiftlang/swift#90370 crash shape; canonical spellings are now methods) + trailer.
+
+---
+
+### Task 2: DocC article + migration-table producer rows
+
+**Files:**
+- Create: `Sources/napkin/napkin.docc/Articles/StreamingStateDownTheTree.md`
+- Modify: `Sources/napkin/napkin.docc/napkin.md` (topics entry)
+- Modify: `Tools/site/llms.txt` (article line)
+- Modify: `Sources/napkin/napkin.docc/Articles/MigratingFromV0.md` (two table rows)
+- Modify: `README.md` (closing links of the streaming section gain the article URL)
+
+- [ ] **Step 1: Author the article** as a DocC lift of README's "Streaming State Down the Tree" section (the README section is the content source of truth — same recipes, same code blocks copied from the snippets' shown regions, same mapping table). Adaptations for DocC: an abstract line under the title; `<details>` blocks become plain subsections titled "The 0.x version this replaces"; in-page README anchors become `<doc:…>` links (`<doc:MigratingFromV0>`, `<doc:Lifecycle>`, `<doc:CrossIsolationPatterns>`, `<doc:SwiftUIIntegration>`); symbol mentions use ``double-backtick`` symbol links where they resolve (``InteractorScope/isActiveStream``, ``Interactable/task(priority:_:)``). Check one existing article (e.g. `MigratingFromV0.md`) for house style and follow it. Mention that every code block is compiled from `Snippets/Streaming/` by `swift build`.
+- [ ] **Step 2: Register it.** Add `- <doc:StreamingStateDownTheTree>` to the appropriate topic group in `napkin.md` (alongside MigratingFromV0/Lifecycle); add a matching line to `Tools/site/llms.txt` following its exact format (`https://getnapkin.to/documentation/napkin/streamingstatedownthetree`: one-line description).
+- [ ] **Step 3: Producer rows.** In `MigratingFromV0.md`'s "Diff, line by line" table, append two rows: `CurrentValueSubject` on a service → an `actor` service vending replay-latest `AsyncStream`s (fresh stream per subscriber) — "Producer recipes in <doc:StreamingStateDownTheTree>."; `PassthroughSubject` → the same fan-out actor minus the initial yield — "No replay.". Match the table's column structure exactly.
+- [ ] **Step 4: README pointer.** In README's streaming-section closing paragraph (the one linking migratingfromv0/lifecycle/crossisolationpatterns), add the article as the primary link: `This section also lives as a DocC article: [Streaming State Down the Tree](https://getnapkin.to/documentation/napkin/streamingstatedownthetree).`
+- [ ] **Step 5: Verify + commit.** Docs build green (`swift package generate-documentation --target napkin`) with the new article included and `<doc:…>` links resolving (no new warnings mentioning StreamingStateDownTheTree). Commit: `docs: DocC article for Streaming State Down the Tree + producer rows` + trailer.
+
+---
+
+### Task 3: run-ribhouse project skill
+
+**Files:**
+- Create: `.claude/skills/run-ribhouse/SKILL.md`
+
+Content will be finalized under superpowers:writing-skills guidance at dispatch time; the verified recipe it must capture (from the 2026-07-02 session): find the iPhone 17 UDID (`xcrun simctl list devices available`), boot + `open -a Simulator`, `xcodebuild … -derivedDataPath <scratch> build`, `simctl install`/`simctl launch <UDID> com.napkin.example.RibHouse -fastTicks`, screenshot via `simctl io <UDID> screenshot`, and drive interactions by running the UI tests (`-only-testing:RibHouseUITests/…`) with a parallel screenshot loop — `simctl` cannot tap. Commit: `chore: project skill for running RibHouse on the simulator` + trailer.
+
+---
+
+### Task 4: Verify, PR, release
+
+- [ ] `swift build && swift test` green; docs build green; `git diff c7bab25..HEAD --stat -- Sources/napkin` shows only `Presenter.swift` (doc comments) + `napkin.docc` files.
+- [ ] Push, `gh pr create --base develop` (summary: the four follow-up groups + links to #153/#154/swiftlang#90370), merge to develop, then develop→main release PR (docs must reach the website), merge, confirm Release + Documentation workflows.


### PR DESCRIPTION
## Summary
Closes out the follow-up queue from #150/#151:
- **Weak-presenter rule applied everywhere docs teach the presenter/view relationship** — the README recipe, its compiled snippet, `Presenter.swift` doc comments, `SwiftUIIntegration.md`, CHANGELOG migration steps, and every residual "reads via `@Bindable`" phrasing. Views hold presenters `weak` (the presenter owns the VC that owns the view); reads are direct `@Observable` access; `@Bindable` is a local rebinding tool in `body`.
- **CHANGELOG migration step 4 no longer recommends the compiler-crashing `Observations` shape** — now teaches the stream form and the main-actor-bound form, citing [swiftlang/swift#90370](https://github.com/swiftlang/swift/issues/90370) (filed with a verified standalone reproducer).
- **DocC alignment**: canonical `userStream()` / `events()` method spellings across Lifecycle/MigratingFromV0/HeadlessNapkins; Observation re-annotation prose added where the examples were already fixed.
- **New DocC article `StreamingStateDownTheTree`** — the README section lifted to getnapkin.to, all 10 code blocks token-identical to the compiled `Snippets/Streaming/` sources; registered in napkin.md + llms.txt; two producer rows added to MigratingFromV0's diff table; README cross-links it.
- **`run-ribhouse` project skill** (`.claude/skills/`, now tracked) — the verified simulator launch-and-drive recipe, application-tested with a cold agent.

Framework `.swift` changes: `Presenter.swift` doc comments only (verified non-comment diff empty).
Related issues: #153, #154 (framework follow-ups, not in this PR).

Plan: `docs/superpowers/plans/2026-07-02-streaming-follow-ups.md`

## Test plan
- `swift build` / `swift test` green (42/42) — the edited snippet still compiles and mirrors verified token-identical (README ↔ article ↔ snippets).
- `swift package generate-documentation` clean; all `<doc:>` and symbol links resolve.
- Whole-branch review + re-review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)