### PR TITLE
Fix: menu-bar version picker opens then instantly closes

### DIFF
--- a/Tools/site/index.html
+++ b/Tools/site/index.html
@@ -79,13 +79,16 @@
                 <li><a href="https://github.com/WikipediaBrown/napkin">GitHub</a></li>
             </ul>
 
-            <label class="masthead__versions" aria-label="Documentation version">
+            <!-- span, not label: a <label> wrapping a <select> re-dispatches the
+                 click to the select, so the native dropdown opens and instantly
+                 closes (double-activation; worst in Safari). -->
+            <span class="masthead__versions">
                 <span aria-hidden="true">§</span>
-                <select onchange="if(this.value)location.href=this.value">
+                <select aria-label="Documentation version" onchange="if(this.value)location.href=this.value">
                     <option value="">version</option>
                     <!-- __VERSION_LINKS__ -->
                 </select>
-            </label>
+            </span>
         </nav>
     </div>
 </header>


### PR DESCRIPTION
## Summary
The masthead version picker's `<select>` was nested inside a `<label>`. Browsers forward a label's click to its control as a second synthetic activation, so the native dropdown opened (activation 1) and immediately closed (forwarded activation 2) — "whenever I click it, it just immediately closes." Worst in Safari, reproducible in Chromium via the label's § prefix area.

Fix: wrapper becomes a `<span>` (CSS class unchanged), and the select carries `aria-label="Documentation version"` so the accessible name is preserved.

## Verification
- Instrumented `pointerdown/mousedown/mouseup/click` listeners in Playwright on the stamped page:
  - **Before:** clicking the pill logged a second `click` retargeted at the `SELECT` (the label re-dispatch)
  - **After:** exactly one click event, no re-dispatch; select opens normally
- `onchange` navigation and keyboard focus unaffected (native select behavior untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)